### PR TITLE
Update LICENSE reference to httplib2.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,4 +19,4 @@ This code has the following dependencies
 above and beyond the Python standard library:
 
 uritemplates - Apache License 2.0
-httplib2 - MIT License
+httplib2 - Apache License 2.0


### PR DESCRIPTION
Current version of the file says that it is MIT license, but httplib2 is MIT license.
