### PR TITLE
Replace uses of `as_string` from the email lib.

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -27,7 +27,9 @@ __all__ = [
 
 
 # Standard library imports
+import StringIO
 import copy
+from email.generator import Generator
 from email.mime.multipart import MIMEMultipart
 from email.mime.nonmultipart import MIMENonMultipart
 import keyword
@@ -728,7 +730,12 @@ def createMethod(methodName, methodDesc, rootDesc, schema):
           payload = media_upload.getbytes(0, media_upload.size())
           msg.set_payload(payload)
           msgRoot.attach(msg)
-          body = msgRoot.as_string()
+          # encode the body: note that we can't use `as_string`, because
+          # it plays games with `From ` lines.
+          fp = StringIO.StringIO()
+          g = Generator(fp, mangle_from_=False)
+          g.flatten(msgRoot, unixfrom=False)
+          body = fp.getvalue()
 
           multipart_boundary = msgRoot.get_boundary()
           headers['content-type'] = ('multipart/related; '

--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1229,7 +1229,12 @@ class BatchHttpRequest(object):
       msg.set_payload(body)
       message.attach(msg)
 
-    body = message.as_string()
+    # encode the body: note that we can't use `as_string`, because
+    # it plays games with `From ` lines.
+    fp = StringIO.StringIO()
+    g = Generator(fp, mangle_from_=False)
+    g.flatten(message, unixfrom=False)
+    body = fp.getvalue()
 
     headers = {}
     headers['content-type'] = ('multipart/mixed; '


### PR DESCRIPTION
The `as_string` function from the `email` module assumes that it's being used
to encode a message for, well, email transmission -- and as a result, it
changes lines beginning with "From " into lines beginning with ">From ". Given
that we're using this for multipart uploads, this is surely not what we want.

We basically inline the body of `as_string`, setting `mangle_from_` to
`False`.

PTAL @skelterjohn
