### PR TITLE
Update Copyright Years on googleapiclient Files

### DIFF
--- a/googleapiclient/__init__.py
+++ b/googleapiclient/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012 Google Inc.
+# Copyright (C) 2014 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010 Google Inc.
+# Copyright (C) 2014 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/googleapiclient/errors.py
+++ b/googleapiclient/errors.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python2.4
 #
-# Copyright (C) 2010 Google Inc.
+# Copyright (C) 2014 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012 Google Inc.
+# Copyright (C) 2014 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/googleapiclient/model.py
+++ b/googleapiclient/model.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python2.4
 #
-# Copyright (C) 2010 Google Inc.
+# Copyright (C) 2014 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/googleapiclient/sample_tools.py
+++ b/googleapiclient/sample_tools.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 Google Inc.
+# Copyright (C) 2014 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/googleapiclient/schema.py
+++ b/googleapiclient/schema.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010 Google Inc.
+# Copyright (C) 2014 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Proposal

Update copyright years on all applicable files
## Reasoning

The copyright years were updated because the code is actively being used (this project is not dead). The only file whose copyright was not changed was `mimeparse.py` as it was copyrighted by Mr. Joe Gregorio and not by Google.
