### PR TITLE
Added requirements file to Django sample

### DIFF
--- a/samples/django_sample/requirements.txt
+++ b/samples/django_sample/requirements.txt
@@ -1,0 +1,2 @@
+Django==1.5.12
+oauth2client==2.2.0

--- a/samples/django_sample/requirements.txt
+++ b/samples/django_sample/requirements.txt
@@ -1,2 +1,3 @@
-Django==1.5.12
+Django==1.4.22
 oauth2client==2.2.0
+google-api-python-client


### PR DESCRIPTION
Added a requirements file to show which packages are needed to be installed for the Django example to actually work.

To set up a virtual environment with these packages do the following:

```
virtualenv --no-site-packages virtualenv
. virtualenv/bin/activate
pip install -r requirements.txt
```
