### PR TITLE
Make Django sample compatible with Django 1.1.0 and oauth2client 3.0.0

### DIFF
--- a/samples/django_sample/plus/models.py
+++ b/samples/django_sample/plus/models.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.contrib.auth.models import User
 from django.db import models
 
-from oauth2client.contrib.django_orm import CredentialsField
+from oauth2client.contrib.django_util.models import CredentialsField
 
 
 class CredentialsModel(models.Model):

--- a/samples/django_sample/plus/models.py
+++ b/samples/django_sample/plus/models.py
@@ -1,11 +1,7 @@
-import pickle
-import base64
-
 from django.contrib import admin
 from django.contrib.auth.models import User
 from django.db import models
 
-from oauth2client.contrib.django_orm import FlowField
 from oauth2client.contrib.django_orm import CredentialsField
 
 

--- a/samples/django_sample/plus/views.py
+++ b/samples/django_sample/plus/views.py
@@ -4,8 +4,6 @@ import httplib2
 
 from googleapiclient.discovery import build
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
-from django.http import HttpResponse
 from django.http import HttpResponseBadRequest
 from django.http import HttpResponseRedirect
 from django.shortcuts import render


### PR DESCRIPTION
Changes that will make the sample compatible with django 1.10 and oauth2client 3.0.0.
- request.REQUEST is deprecated in django 1.9 [Fields Removed in 1.9](https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-9)
- oauth2client moved CredentialField from django_orm to django_util
