### PR TITLE
add path for client_secrets.json in sample_tools.py

### DIFF
--- a/googleapiclient/sample_tools.py
+++ b/googleapiclient/sample_tools.py
@@ -72,7 +72,7 @@ def init(argv, name, version, doc, filename, scope=None, parents=[], discovery_f
   # application, including client_id and client_secret, which are found
   # on the API Access tab on the Google APIs
   # Console <http://code.google.com/apis/console>.
-  client_secrets = os.path.join(os.path.dirname(filename),
+  client_secrets = os.path.join(os.path.dirname(filename), os.getcwd(),
                                 'client_secrets.json')
 
   # Set up a Flow object to be used if we need to authenticate.


### PR DESCRIPTION
I add path for client_secrets.json in sample_tools.py, because we have some accounts then we need to prepare some client_secrets.json.
To use the same script with several json files, I made each directory and set env files in the directories.  