### PR TITLE
Match travis matrix with tox testenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,41 @@ cache:
 matrix:
   include:
   - python: 2.7
-    env: TOXENV=py27
+    env: TOXENV=py27-oauth2client1
+  - python: 2.7
+    env: TOXENV=py27-oauth2client2
+  - python: 2.7
+    env: TOXENV=py27-oauth2client3
+  - python: 2.7
+    env: TOXENV=py27-oauth2client4
+
   - python: 3.4
-    env: TOXENV=py34
+    env: TOXENV=py34-oauth2client1
+  - python: 3.4
+    env: TOXENV=py34-oauth2client2
+  - python: 3.4
+    env: TOXENV=py34-oauth2client3
+  - python: 3.4
+    env: TOXENV=py34-oauth2client4
+
   - python: 3.5
-    env: TOXENV=py35
+    env: TOXENV=py35-oauth2client1
+  - python: 3.5
+    env: TOXENV=py35-oauth2client2
+  - python: 3.5
+    env: TOXENV=py35-oauth2client3
+  - python: 3.5
+    env: TOXENV=py35-oauth2client4
+
   - python: 3.6
-    env: TOXENV=py36
+    env: TOXENV=py36-oauth2client1
+  - python: 3.6
+    env: TOXENV=py36-oauth2client2
+  - python: 3.6
+    env: TOXENV=py36-oauth2client3
+  - python: 3.6
+    env: TOXENV=py36-oauth2client4
+
 install:
 - pip install tox coveralls
 script:


### PR DESCRIPTION
Executing tox in the project directory is not the same of what is being
executed in travis-ci
It was causing problems when replacing oauth2client library by google-auth
in the setup.py because oauth2client is mandatory for tests, and travis
was not installing oauth2client if it is not in the setup.py.
Also it is good to keep the consistency of the test environments.