### PR TITLE
Change xrange to range

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1196,7 +1196,7 @@ class TestBatch(unittest.TestCase):
     from googleapiclient.http import MAX_BATCH_LIMIT
 
     batch = BatchHttpRequest()
-    for i in xrange(0, MAX_BATCH_LIMIT):
+    for i in range(0, MAX_BATCH_LIMIT):
       batch.add(HttpRequest(
         None,
         None,


### PR DESCRIPTION
`xrange` does not exist in Python 3 and this is causing Python 3 tests to fail. 