### PR TITLE
Call original request method with kwargs.

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1720,8 +1720,8 @@ def set_user_agent(http, user_agent):
       headers['user-agent'] = user_agent + ' ' + headers['user-agent']
     else:
       headers['user-agent'] = user_agent
-    resp, content = request_orig(uri, method, body, headers,
-                        redirections, connection_type)
+    resp, content = request_orig(uri, method=method, body=body, headers=headers,
+                        redirections=redirections, connection_type=connection_type)
     return resp, content
 
   http.request = new_request
@@ -1761,8 +1761,8 @@ def tunnel_patch(http):
             'OAuth 1.0 request made with Credentials after tunnel_patch.')
       headers['x-http-method-override'] = "PATCH"
       method = 'POST'
-    resp, content = request_orig(uri, method, body, headers,
-                        redirections, connection_type)
+    resp, content = request_orig(uri, method=method, body=body, headers=headers,
+                        redirections=redirections, connection_type=connection_type)
     return resp, content
 
   http.request = new_request


### PR DESCRIPTION
This should allows for `set_user_agent` and `tunnel_patch` to be used with an instance of google-auth-library-python-httplib's [AuthorizedHttp](https://github.com/GoogleCloudPlatform/google-auth-library-python-httplib2/blob/e7cd722281d1d897fa9ae6e3b6b78ae142778e6e/google_auth_httplib2.py#L178).

Closes #656.
