### PR TITLE
Never require 'body' for requests.

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -96,7 +96,6 @@ _MEDIA_SIZE_BIT_SHIFTS = {'KB': 10, 'MB': 20, 'GB': 30, 'TB': 40}
 BODY_PARAMETER_DEFAULT_VALUE = {
     'description': 'The request body.',
     'type': 'object',
-    'required': True,
 }
 MEDIA_BODY_PARAMETER_DEFAULT_VALUE = {
     'description': ('The filename of the media request body, or an instance '
@@ -494,9 +493,6 @@ def _fix_up_parameters(method_desc, root_desc, http_method, schema):
   if http_method in HTTP_PAYLOAD_METHODS and 'request' in method_desc:
     body = BODY_PARAMETER_DEFAULT_VALUE.copy()
     body.update(method_desc['request'])
-    # Make body optional for requests with no parameters.
-    if not _methodProperties(method_desc, schema, 'request'):
-      body['required'] = False
     parameters['body'] = body
 
   return parameters
@@ -505,10 +501,8 @@ def _fix_up_parameters(method_desc, root_desc, http_method, schema):
 def _fix_up_media_upload(method_desc, root_desc, path_url, parameters):
   """Adds 'media_body' and 'media_mime_type' parameters if supported by method.
 
-  SIDE EFFECTS: If the method supports media upload and has a required body,
-  sets body to be optional (required=False) instead. Also, if there is a
-  'mediaUpload' in the method description, adds 'media_upload' key to
-  parameters.
+  SIDE EFFECTS: If there is a 'mediaUpload' in the method description, adds
+  'media_upload' key to parameters.
 
   Args:
     method_desc: Dictionary with metadata describing an API method. Value comes
@@ -541,8 +535,6 @@ def _fix_up_media_upload(method_desc, root_desc, path_url, parameters):
     media_path_url = _media_path_url_from_info(root_desc, path_url)
     parameters['media_body'] = MEDIA_BODY_PARAMETER_DEFAULT_VALUE.copy()
     parameters['media_mime_type'] = MEDIA_MIME_TYPE_PARAMETER_DEFAULT_VALUE.copy()
-    if 'body' in parameters:
-      parameters['body']['required'] = False
 
   return accept, max_size, media_path_url
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -162,7 +162,6 @@ class Utilities(unittest.TestCase):
     body = {
         'description': 'The request body.',
         'type': 'object',
-        'required': True,
         '$ref': 'Animal',
     }
     self.assertEqual(parameters['body'], body)
@@ -206,7 +205,6 @@ class Utilities(unittest.TestCase):
     body = {
         'description': 'The request body.',
         'type': 'object',
-        'required': True,
         '$ref': 'Request',
         'key1': 'value1',
         'key2': 'value2',
@@ -219,7 +217,6 @@ class Utilities(unittest.TestCase):
     method_desc = {'request': {'$ref': 'Request'}}
 
     parameters = _fix_up_parameters(method_desc, {}, 'POST', dummy_schema)
-    self.assertFalse(parameters['body']['required'])
 
   def _base_fix_up_method_description_test(
       self, method_desc, initial_parameters, final_parameters,
@@ -267,7 +264,7 @@ class Utilities(unittest.TestCase):
   def test_fix_up_media_upload_with_initial_valid_minimal(self):
     valid_method_desc = {'mediaUpload': {'accept': []}}
     initial_parameters = {'body': {}}
-    final_parameters = {'body': {'required': False},
+    final_parameters = {'body': {},
                         'media_body': MEDIA_BODY_PARAMETER_DEFAULT_VALUE,
                         'media_mime_type': MEDIA_MIME_TYPE_PARAMETER_DEFAULT_VALUE}
     self._base_fix_up_method_description_test(
@@ -277,7 +274,7 @@ class Utilities(unittest.TestCase):
   def test_fix_up_media_upload_with_initial_valid_full(self):
     valid_method_desc = {'mediaUpload': {'accept': ['*/*'], 'maxSize': '10GB'}}
     initial_parameters = {'body': {}}
-    final_parameters = {'body': {'required': False},
+    final_parameters = {'body': {},
                         'media_body': MEDIA_BODY_PARAMETER_DEFAULT_VALUE,
                         'media_mime_type': MEDIA_MIME_TYPE_PARAMETER_DEFAULT_VALUE}
     ten_gb = 10 * 2**30


### PR DESCRIPTION
Fixes #713. 

Never require that a `body` be passed in a request. Validation of `body` will be left to the server.