### PR TITLE
docs: fix argument typo in code example

### DIFF
--- a/docs/oauth-installed.md
+++ b/docs/oauth-installed.md
@@ -78,7 +78,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 
 flow = InstalledAppFlow.from_client_secrets_file(
     'client_secret.json',
-    scope=['https://www.googleapis.com/auth/drive.metadata.readonly'])
+    scopes=['https://www.googleapis.com/auth/drive.metadata.readonly'])
 ```
 
 Your application uses the client object to perform OAuth 2.0 operations, such as generating authorization request URIs and applying access tokens to HTTP requests.


### PR DESCRIPTION
I noticed a small typo in a code snippet from the OAuth docs. 

The the class method [`google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file `](https://github.com/googleapis/google-auth-library-python-oauthlib/blob/master/google_auth_oauthlib/flow.py#L182) has two args `client_secrets_file` and `scopes`.

Hope this helps 👋 