### PR TITLE
docs: recommend install with virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,30 @@ For Google Cloud Platform APIs such as Datastore, Cloud Storage or Pub/Sub, we r
 
 ## Installation
 
-To install, simply use `pip` or `easy_install`:
+Install this library in a [virtualenv](https://virtualenv.pypa.io/en/latest/) using pip. virtualenv is a tool to
+create isolated Python environments. The basic problem it addresses is one of
+dependencies and versions, and indirectly permissions.
 
-```bash
-pip install --upgrade google-api-python-client
+With virtualenv, it's possible to install this library without needing system
+install permissions, and without clashing with the installed system
+dependencies.
+
+### Mac/Linux
+
+```
+pip install virtualenv
+virtualenv <your-env>
+source <your-env>/bin/activate
+<your-env>/bin/pip install google-api-python-client
 ```
 
-or
+### Windows
 
-```bash
-easy_install --upgrade google-api-python-client
+```
+pip install virtualenv
+virtualenv <your-env>
+<your-env>\Scripts\activate
+<your-env>\Scripts\pip.exe install google-api-python-client
 ```
 
 ## Supported Python Versions


### PR DESCRIPTION
Copied from google-cloud-python install docs: https://github.com/googleapis/google-cloud-python/blob/master/storage/README.rst