### PR TITLE
chore(docs): fix capitalization in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Google API Client LIbrary for Python Docs
+# Google API Client Library for Python Docs
 
  The Google API Client Library for Python is designed for Python
 client-application developers. It offers simple, flexible


### PR DESCRIPTION
Library was spelt `LIbrary` with both L and I capitalized