### PR TITLE
Fixed [appplication] OAuth 2.0 documentation typo

### DIFF
--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -45,7 +45,7 @@ flow.run_local_server()
 
 ### Flow
 
-The example below uses the `Flow` class to handle the installed appplication authorization flow.
+The example below uses the `Flow` class to handle the installed application authorization flow.
 
 #### from_client_secrets_file()
 


### PR DESCRIPTION
This PR fixes a small typo that I found checking the [OAuth 2.0](https://github.com/googleapis/google-api-python-client/blob/master/docs/oauth.md) Markdown documentation.

From
```The example below uses the `Flow` class to handle the installed appplication authorization flow.```

To
```The example below uses the `Flow` class to handle the installed application authorization flow.```

Thanks. 👍 