### PR TITLE
fix: add try/except around file descriptor close

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -575,7 +575,10 @@ class MediaFileUpload(MediaIoBaseUpload):
         )
 
     def __del__(self):
-        self._fd.close()
+        try:
+            self._fd.close()
+        except AttributeError:
+            pass
 
     def to_json(self):
         """Creating a JSON representation of an instance of MediaFileUpload.


### PR DESCRIPTION
If a nonexistent filename is passed, `self._fd` is never initialized. The destructor still attempts to close the file descriptor. This obscures the real error (file not existing).

Closes #798 

quickstart.py
```py
from __future__ import print_function
import pickle
import os.path
from googleapiclient.discovery import build
from googleapiclient.http import MediaFileUpload
from google_auth_oauthlib.flow import InstalledAppFlow
from google.auth.transport.requests import Request

# If modifying these scopes, delete the file token.pickle.
SCOPES = ['https://www.googleapis.com/auth/drive']

def main():
    creds = None
    # The file token.pickle stores the user's access and refresh tokens, and is
    # created automatically when the authorization flow completes for the first
    # time.
    if os.path.exists('token.pickle'):
        with open('token.pickle', 'rb') as token:
            creds = pickle.load(token)
    # If there are no (valid) credentials available, let the user log in.
    if not creds or not creds.valid:
        if creds and creds.expired and creds.refresh_token:
            creds.refresh(Request())
        else:
            flow = InstalledAppFlow.from_client_secrets_file(
                'credentials.json', SCOPES)
            creds = flow.run_local_server(port=0)
        # Save the credentials for the next run
        with open('token.pickle', 'wb') as token:
            pickle.dump(creds, token)

    service = build('drive', 'v3', credentials=creds)

    file_metadata = {'name': 'foo.jpg'}
    media = MediaFileUpload('files/foo.jpg',
                            mimetype='image/jpeg')
    file = service.files().create(body=file_metadata,
                                        media_body=media,
                                        fields='id').execute()
    print ('File ID: %s' % file.get('id'))

if __name__ == '__main__':
    main()
```

```
Traceback (most recent call last):
  File "quickstart.py", line 46, in <module>
    main()
  File "quickstart.py", line 39, in main
    mimetype='image/jpeg')
  File "/usr/local/google/home/busunkim/misc/fixit/drive-quickstart/env/lib/python3.7/site-packages/googleapiclient/_helpers.py", line 130, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/usr/local/google/home/busunkim/misc/fixit/drive-quickstart/env/lib/python3.7/site-packages/googleapiclient/http.py", line 555, in __init__
    fd = open(self._filename, 'rb')
FileNotFoundError: [Errno 2] No such file or directory: 'files/foo.jpg'
Exception ignored in: <function MediaFileUpload.__del__ at 0x7f33b398c680>
Traceback (most recent call last):
  File "/usr/local/google/home/busunkim/misc/fixit/drive-quickstart/env/lib/python3.7/site-packages/googleapiclient/http.py", line 567, in __del__
    if hasattr(self, _fd):
NameError: name '_fd' is not defined
```
