### PR TITLE
fix: handle no content for all 2xx responses

### DIFF
--- a/googleapiclient/model.py
+++ b/googleapiclient/model.py
@@ -216,6 +216,9 @@ class BaseModel(Model):
                 # A 204: No Content response should be treated differently
                 # to all the other success states
                 return self.no_content_response
+            elif not content:
+                # An empty response cannot be deserialized
+                return self.no_content_response
             return self.deserialize(content)
         else:
             LOGGER.debug("Content from bad request was: %s" % content)

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -223,10 +223,19 @@ class Model(unittest.TestCase):
         content = model.response(resp, content)
         self.assertEqual(content, "data goes here")
 
-    def test_no_content_response(self):
+    def test_no_content_204_response(self):
         model = JsonModel(data_wrapper=False)
         resp = httplib2.Response({"status": "204"})
         resp.reason = "No Content"
+        content = ""
+
+        content = model.response(resp, content)
+        self.assertEqual(content, {})
+
+    def test_no_content_200_response(self):
+        model = JsonModel(data_wrapper=False)
+        resp = httplib2.Response({"status": "200"})
+        resp.reason = "OK"
         content = ""
 
         content = model.response(resp, content)


### PR DESCRIPTION
Some API's can return a content-length of 0 for Status 200 OK
responses that then results in a ValueError.

This change returns the expected response for no content if it detects
a response containing no content.

This commit fixes issue #804