### PR TITLE
fix: don't set http.redirect_codes if the attr doesn't exist

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1891,6 +1891,13 @@ def build_http():
     # for Resumable Uploads rather than Permanent Redirects.
     # This asks httplib2 to exclude 308s from the status codes
     # it treats as redirects
-    http.redirect_codes = http.redirect_codes - {308}
+    try:
+      http.redirect_codes = http.redirect_codes - {308}
+    except AttributeError:
+      # Apache Beam tests depend on this library and cannot
+      # currently upgrade their httplib2 version
+      # http.redirect_codes does not exist in previous versions
+      # of httplib2, so pass
+      pass
 
     return http

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ from setuptools import setup
 packages = ["apiclient", "googleapiclient", "googleapiclient/discovery_cache"]
 
 install_requires = [
-    "httplib2>=0.17.0,<1dev",
+    "httplib2>=0.9.2,<1dev",
     "google-auth>=1.4.1",
     "google-auth-httplib2>=0.0.3",
     "google-api-core>=1.13.0,<2dev",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ from setuptools import setup
 packages = ["apiclient", "googleapiclient", "googleapiclient/discovery_cache"]
 
 install_requires = [
-    # NOTE: Apache Beam tests depend on this library and cannot currently
+    # NOTE: Apache Beam tests depend on this library and cannot
     # currently upgrade their httplib2 version.
     # Please see https://github.com/googleapis/google-api-python-client/pull/841
     "httplib2>=0.9.2,<1dev",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ from setuptools import setup
 packages = ["apiclient", "googleapiclient", "googleapiclient/discovery_cache"]
 
 install_requires = [
+    # NOTE: This range for httplib2 was intentionally widened.
+    # Please see https://github.com/googleapis/google-api-python-client/pull/841
+    # before changing the version change.
     "httplib2>=0.9.2,<1dev",
     "google-auth>=1.4.1",
     "google-auth-httplib2>=0.0.3",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ packages = ["apiclient", "googleapiclient", "googleapiclient/discovery_cache"]
 install_requires = [
     # NOTE: This range for httplib2 was intentionally widened.
     # Please see https://github.com/googleapis/google-api-python-client/pull/841
-    # before changing the version change.
+    # before changing the version range.
     "httplib2>=0.9.2,<1dev",
     "google-auth>=1.4.1",
     "google-auth-httplib2>=0.0.3",

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,9 @@ from setuptools import setup
 packages = ["apiclient", "googleapiclient", "googleapiclient/discovery_cache"]
 
 install_requires = [
-    # NOTE: This range for httplib2 was intentionally widened.
+    # NOTE: Apache Beam tests depend on this library and cannot currently
+    # currently upgrade their httplib2 version.
     # Please see https://github.com/googleapis/google-api-python-client/pull/841
-    # before changing the version range.
     "httplib2>=0.9.2,<1dev",
     "google-auth>=1.4.1",
     "google-auth-httplib2>=0.0.3",


### PR DESCRIPTION
This allows folks who can't upgrade their httplib2 version to use the latest version of the library. Note that it is still strongly recommended that you upgrade (see [install_requires](https://github.com/googleapis/google-api-python-client/blob/master/setup.py#L36)). 

@aaltay is there an issue tracking the httplib2 upgrade I can link to? I'd like this to be removed eventually.