### PR TITLE
Fix "byteswarning" errors in http and model modules

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1760,16 +1760,18 @@ class HttpMockSequence(object):
         connection_type=None,
     ):
         resp, content = self._iterable.pop(0)
-        if content == "echo_request_headers":
+        content = six.ensure_binary(content)
+
+        if content == b"echo_request_headers":
             content = headers
-        elif content == "echo_request_headers_as_json":
+        elif content == b"echo_request_headers_as_json":
             content = json.dumps(headers)
-        elif content == "echo_request_body":
+        elif content == b"echo_request_body":
             if hasattr(body, "read"):
                 content = body.read()
             else:
                 content = body
-        elif content == "echo_request_uri":
+        elif content == b"echo_request_uri":
             content = uri
         if isinstance(content, six.text_type):
             content = content.encode("utf-8")

--- a/googleapiclient/model.py
+++ b/googleapiclient/model.py
@@ -218,7 +218,7 @@ class BaseModel(Model):
                 return self.no_content_response
             return self.deserialize(content)
         else:
-            LOGGER.debug("Content from bad request was: %s" % content)
+            LOGGER.debug("Content from bad request was: %r" % content)
             raise HttpError(resp, content)
 
     def serialize(self, body_value):


### PR DESCRIPTION
This change fixes a few error prone interactions with `str` and `bytes` type objects which surface as exceptions when the `googleapiclient` library tests are run with the `-bb` command line flag

See https://docs.python.org/3/using/cmdline.html#cmdoption-b