### PR TITLE
fix: replace '-' in method names with '_'

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -131,10 +131,10 @@ def fix_method_name(name):
     name: string, method name.
 
   Returns:
-    The name with '_' appended if the name is a reserved word and '$' 
+    The name with '_' appended if the name is a reserved word and '$' and '-'
     replaced with '_'. 
   """
-    name = name.replace("$", "_")
+    name = name.replace("$", "_").replace("-", "_")
     if keyword.iskeyword(name) or name in RESERVED_WORDS:
         return name + "_"
     else:


### PR DESCRIPTION
The Healthcare API has a resource named 'Patient-everything' which is unaccessible because the hyphen makes it an invalid name.

https://healthcare.googleapis.com/$discovery/rest?version=v1
```
          "Patient-everything": {
                          "response": {
                            "$ref": "HttpBody"
                          },
```

This change replaces the '-' with a '_'.

```py
from googleapiclient import discovery


service = discovery.build("healthcare", "v1")

service.projects().locations().datasets().fhirStores().fhir().Patient_everything(name='...')
```

CC @noerog