### PR TITLE
docs: drop 3.4 from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ virtualenv <your-env>
 
 ## Supported Python Versions
 
-Python 3.4, 3.5, 3.6 and 3.7 are fully supported and tested. This library may work on later versions of 3, but we do not currently run tests against those versions
+Python 3.5, 3.6 and 3.7, and 3.8 are fully supported and tested. This library may work on later versions of 3, but we do not currently run tests against those versions
 
 ## Deprecated Python Versions
 


### PR DESCRIPTION
3.4 is no longer being tested and has been removed from the setup.py