### PR TITLE
Remove apiclient.__version__

### DIFF
--- a/apiclient/__init__.py
+++ b/apiclient/__init__.py
@@ -19,8 +19,6 @@ except ImportError:
     sample_tools = None
 from googleapiclient import schema
 
-__version__ = googleapiclient.__version__
-
 _SUBMODULES = {
     "channel": channel,
     "discovery": discovery,


### PR DESCRIPTION
Hello,

We have removed __version__ var from googleapiclient/__init__.py
https://github.com/googleapis/google-api-python-client/commit/f706cfd821ab7457e5db37abfc3619772657dd0e#diff-b926d296d4c856bcbf877809e4523562L15
so it won't work anymore.

https://github.com/googleapis/google-api-python-client/issues/870

CC: @busunkim96
Fixes #870 🐈
