### PR TITLE
test: use self.MOCK_CREDENTIALS in tests

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -535,7 +535,7 @@ class DiscoveryFromDocument(unittest.TestCase):
         plus = build_from_document(
             discovery, 
             client_options={"api_endpoint": api_endpoint},
-            credentials=self.MOCK_CREDENTIAL
+            credentials=self.MOCK_CREDENTIALS
         )
 
         self.assertEqual(plus._baseUrl, api_endpoint)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -521,7 +521,8 @@ class DiscoveryFromDocument(unittest.TestCase):
         options = google.api_core.client_options.ClientOptions(
             api_endpoint=api_endpoint
         )
-        plus = build_from_document(discovery,
+        plus = build_from_document(
+            discovery,
             client_options=options,
             credentials=self.MOCK_CREDENTIALS
         )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -521,7 +521,10 @@ class DiscoveryFromDocument(unittest.TestCase):
         options = google.api_core.client_options.ClientOptions(
             api_endpoint=api_endpoint
         )
-        plus = build_from_document(discovery, client_options=options)
+        plus = build_from_document(discovery,
+            client_options=options,
+            credentials=self.MOCK_CREDENTIALS
+        )
 
         self.assertEqual(plus._baseUrl, api_endpoint)
 
@@ -529,7 +532,9 @@ class DiscoveryFromDocument(unittest.TestCase):
         discovery = open(datafile("plus.json")).read()
         api_endpoint = "https://foo.googleapis.com/"
         plus = build_from_document(
-            discovery, client_options={"api_endpoint": api_endpoint}
+            discovery, 
+            client_options={"api_endpoint": api_endpoint},
+            credentials=self.MOCK_CREDENTIAL
         )
 
         self.assertEqual(plus._baseUrl, api_endpoint)


### PR DESCRIPTION
Our tests were passing because `GOOGLE_APPLICATION_CREDENTIALS` are in the environment, but this should technically use mock credentials.