### PR TITLE
fix: don't try to import GAE API in other environments

### DIFF
--- a/googleapiclient/discovery_cache/__init__.py
+++ b/googleapiclient/discovery_cache/__init__.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 
 import logging
 import datetime
-
+import os
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,16 +32,18 @@ def autodetect():
     googleapiclient.discovery_cache.base.Cache, a cache object which
     is auto detected, or None if no cache object is available.
   """
-    try:
-        from google.appengine.api import memcache
-        from . import appengine_memcache
-
-        return appengine_memcache.cache
-    except Exception:
+    if 'APPENGINE_RUNTIME' in os.environ:
         try:
-            from . import file_cache
+            from google.appengine.api import memcache
+            from . import appengine_memcache
 
-            return file_cache.cache
-        except Exception as e:
-            LOGGER.warning(e, exc_info=True)
-            return None
+            return appengine_memcache.cache
+        except Exception:
+            pass
+    try:
+        from . import file_cache
+
+        return file_cache.cache
+    except Exception as e:
+        LOGGER.warning(e, exc_info=True)
+        return None

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -648,6 +648,14 @@ class DiscoveryFromHttp(unittest.TestCase):
 
 
 class DiscoveryFromAppEngineCache(unittest.TestCase):
+
+    def setUp(self):
+        self.old_environ = os.environ.copy()
+        os.environ["APPENGINE_RUNTIME"] = "python27"
+
+    def tearDown(self):
+        os.environ = self.old_environ
+
     def test_appengine_memcache(self):
         # Hack module import
         self.orig_import = __import__


### PR DESCRIPTION
The GAE memcache API isn't supported in python3. This change gives
callers a new way to ensure that googleapiclient doesn't even try
to import and use this legacy API.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-api-python-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #902 🦕
