### PR TITLE
fix: use older version of nox to fix test failure

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -33,7 +33,7 @@ export PROJECT_ID=$(cat "${KOKORO_GFILE_DIR}/project-id.json")
 python3.6 -m pip uninstall --yes --quiet nox-automation
 
 # Install nox
-python3.6 -m pip install --upgrade --quiet nox
+python3.6 -m pip install --quiet nox==2019.11.9
 python3.6 -m nox --version
 
 python3.6 -m nox


### PR DESCRIPTION
latest version (2020.5.24) of nox breaks all unit tests, we have to use the previous version (2019.11.9). As a comparison, this "empty" PR #922 uses the latest version and all unit tests fail. #921 fails for the same reason.

```
Session unit-2.7 raised exception TypeError("unit() missing 1 required positional argument: 'oauth2client'",)
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/nox/sessions.py", line 462, in execute
    self.func(session)
  File "/usr/local/lib/python3.6/site-packages/nox/_decorators.py", line 53, in __call__
    return self.func(*args, **kwargs)
TypeError: unit() missing 1 required positional argument: 'oauth2client'
```