### PR TITLE
fix: fix python-api-core dependency issue

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -441,7 +441,11 @@ def build_from_document(
             raise MutualTLSChannelError(
                 "ClientOptions.client_cert_source is not supported, please use ClientOptions.client_encrypted_cert_source."
             )
-        if client_options and client_options.client_encrypted_cert_source:
+        if (
+            client_options
+            and hasattr(client_options, "client_encrypted_cert_source")
+            and client_options.client_encrypted_cert_source
+        ):
             client_cert_to_use = client_options.client_encrypted_cert_source
         elif adc_cert_path and adc_key_path and mtls.has_default_client_cert_source():
             client_cert_to_use = mtls.default_client_encrypted_cert_source(

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
     "httplib2>=0.9.2,<1dev",
     "google-auth>=1.16.0",
     "google-auth-httplib2>=0.0.3",
-    "google-api-core>=1.13.0,<2dev",
+    "google-api-core>=1.17.0,<2dev",
     "six>=1.6.1,<2dev",
     "uritemplate>=3.0.0,<4dev",
 ]


### PR DESCRIPTION
`ClientOptions` doesn't have `client_encryted_cert_source` property yet. Check the existence of the property before accessing it.
