### PR TITLE
fix: bump api-core version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -55,10 +55,6 @@ def lint(session):
     ],
 )
 def unit(session, oauth2client):
-    session.install(
-        "-e",
-        "git+https://github.com/googleapis/python-api-core.git@master#egg=google-api-core",
-    )
     session.install(*test_dependencies)
     session.install(oauth2client)
     if session.python < "3.0":

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
     "httplib2>=0.9.2,<1dev",
     "google-auth>=1.16.0",
     "google-auth-httplib2>=0.0.3",
-    "google-api-core>=1.17.0,<2dev",
+    "google-api-core>=1.18.0,<2dev",
     "six>=1.6.1,<2dev",
     "uritemplate>=3.0.0,<4dev",
 ]


### PR DESCRIPTION
bump api-core version to take `client_encrypted_cert_source` from `ClientOptions`.
