### PR TITLE
fix: prefer V2 Discovery URI format

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -238,7 +238,7 @@ def build(
     else:
         discovery_http = http
 
-    for discovery_url in (discoveryServiceUrl, V2_DISCOVERY_URI):
+    for discovery_url in (V2_DISCOVERY_URI, discoveryServiceUrl):
         requested_url = uritemplate.expand(discovery_url, params)
 
         try:


### PR DESCRIPTION
v2 is now preferred

229/263 APIs list the v2 style in the discovery directory.

https://www.googleapis.com/discovery/v1/apis

(Unit tests need to be updated to expect the v2 URI).