### PR TITLE
fix: update GOOGLE_API_USE_MTLS values

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -471,17 +471,17 @@ def build_from_document(
             not client_options or not client_options.api_endpoint
         ):
             mtls_endpoint = urljoin(service["mtlsRootUrl"], service["servicePath"])
-            use_mtls_env = os.getenv("GOOGLE_API_USE_MTLS", "Never")
+            use_mtls_env = os.getenv("GOOGLE_API_USE_MTLS", "never")
 
-            if not use_mtls_env in ("Never", "Auto", "Always"):
+            if not use_mtls_env in ("never", "auto", "always"):
                 raise MutualTLSChannelError(
-                    "Unsupported GOOGLE_API_USE_MTLS value. Accepted values: Never, Auto, Always"
+                    "Unsupported GOOGLE_API_USE_MTLS value. Accepted values: never, auto, always"
                 )
 
-            # Switch to mTLS endpoint, if environment variable is "Always", or
-            # environment varibable is "Auto" and client cert exists.
-            if use_mtls_env == "Always" or (
-                use_mtls_env == "Auto" and client_cert_to_use
+            # Switch to mTLS endpoint, if environment variable is "always", or
+            # environment varibable is "auto" and client cert exists.
+            if use_mtls_env == "always" or (
+                use_mtls_env == "auto" and client_cert_to_use
             ):
                 base = mtls_endpoint
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -590,9 +590,9 @@ class DiscoveryFromDocumentMutualTLS(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("Never", REGULAR_ENDPOINT),
-            ("Auto", MTLS_ENDPOINT),
-            ("Always", MTLS_ENDPOINT),
+            ("never", REGULAR_ENDPOINT),
+            ("auto", MTLS_ENDPOINT),
+            ("always", MTLS_ENDPOINT),
         ]
     )
     def test_mtls_with_provided_client_cert(self, use_mtls_env, base_url):
@@ -610,7 +610,7 @@ class DiscoveryFromDocumentMutualTLS(unittest.TestCase):
             self.check_http_client_cert(plus, has_client_cert=True)
             self.assertEqual(plus._baseUrl, base_url)
 
-    @parameterized.expand(["Never", "Auto", "Always"])
+    @parameterized.expand(["never", "auto", "always"])
     def test_endpoint_not_switch(self, use_mtls_env):
         # Test endpoint is not switched if user provided api endpoint
         discovery = open(datafile("plus.json")).read()
@@ -630,9 +630,9 @@ class DiscoveryFromDocumentMutualTLS(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("Never", REGULAR_ENDPOINT),
-            ("Auto", MTLS_ENDPOINT),
-            ("Always", MTLS_ENDPOINT),
+            ("never", REGULAR_ENDPOINT),
+            ("auto", MTLS_ENDPOINT),
+            ("always", MTLS_ENDPOINT),
         ]
     )
     @mock.patch(
@@ -667,9 +667,9 @@ class DiscoveryFromDocumentMutualTLS(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("Never", REGULAR_ENDPOINT),
-            ("Auto", REGULAR_ENDPOINT),
-            ("Always", MTLS_ENDPOINT),
+            ("never", REGULAR_ENDPOINT),
+            ("auto", REGULAR_ENDPOINT),
+            ("always", MTLS_ENDPOINT),
         ]
     )
     @mock.patch(


### PR DESCRIPTION
Go client used lower case, so change the values to lower case in python apiary client.
