### PR TITLE
fix: discovery uses V2 when version is None

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -837,6 +837,37 @@ class DiscoveryFromHttp(unittest.TestCase):
         )
         self.assertEqual(zoo._baseUrl, api_endpoint)
 
+    def test_discovery_with_empty_version_uses_v2(self):
+        http = HttpMockSequence(
+            [
+                ({"status": "200"}, read_datafile("zoo.json", "rb")),
+            ]
+        )
+        build("zoo", version=None, http=http, cache_discovery=False)
+        validate_discovery_requests(self, http, "zoo", None, V2_DISCOVERY_URI)
+
+    def test_discovery_with_empty_version_preserves_custom_uri(self):
+        http = HttpMockSequence(
+            [
+                ({"status": "200"}, read_datafile("zoo.json", "rb")),
+            ]
+        )
+        custom_discovery_uri = "https://foo.bar/$discovery"
+        build(
+            "zoo", version=None, http=http,
+            cache_discovery=False, discoveryServiceUrl=custom_discovery_uri)
+        validate_discovery_requests(
+            self, http, "zoo", None, custom_discovery_uri)
+
+    def test_discovery_with_valid_version_uses_v1(self):
+        http = HttpMockSequence(
+            [
+                ({"status": "200"}, read_datafile("zoo.json", "rb")),
+            ]
+        )
+        build("zoo", version="v123", http=http, cache_discovery=False)
+        validate_discovery_requests(self, http, "zoo", "v123", V1_DISCOVERY_URI)
+
 
 class DiscoveryRetryFromHttp(unittest.TestCase):
     def test_repeated_500_retries_and_fails(self):


### PR DESCRIPTION
Passing version=None to discovery.build(), with intent to always
get the latest version of the discovery document,
no longer attempts to use Discovery V1, which fails with
Bad Request errors.
Instead, it uses Discovery V2, which supports null version use case.

Fixes: #971 