### PR TITLE
Fixed two broken links in API Reference Index

### DIFF
--- a/docs/dyn/index.md
+++ b/docs/dyn/index.md
@@ -299,8 +299,8 @@
 
 
 ## dfareporting
-* [v3.3](http://googleapis.github.io/google-api-python-client/docs/dyn/dfareporting_v3.3.html)
-* [v3.4](http://googleapis.github.io/google-api-python-client/docs/dyn/dfareporting_v3.4.html)
+* [v3.3](http://googleapis.github.io/google-api-python-client/docs/dyn/dfareporting_v3_3.html)
+* [v3.4](http://googleapis.github.io/google-api-python-client/docs/dyn/dfareporting_v3_4.html)
 
 
 ## dialogflow


### PR DESCRIPTION
I encountered a 404 link when navigating to the dfareporting documentation.  The issue was with a period that should be an underscore.  I tested the new links, forked and am submitting these back for the next person down the road.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-api-python-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
