### PR TITLE
fix: Update setup.py to install httplib2>=0.15.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,6 @@ from setuptools import setup
 packages = ["apiclient", "googleapiclient", "googleapiclient/discovery_cache"]
 
 install_requires = [
-    # NOTE: Apache Beam tests depend on this library and cannot
-    # currently upgrade their httplib2 version.
-    # Please see https://github.com/googleapis/google-api-python-client/pull/841
     "httplib2>=0.15.0,<1dev",
     "google-auth>=1.16.0",
     "google-auth-httplib2>=0.0.3",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     # NOTE: Apache Beam tests depend on this library and cannot
     # currently upgrade their httplib2 version.
     # Please see https://github.com/googleapis/google-api-python-client/pull/841
-    "httplib2>=0.9.2,<1dev",
+    "httplib2>=0.15.0,<1dev",
     "google-auth>=1.16.0",
     "google-auth-httplib2>=0.0.3",
     "google-api-core>=1.21.0,<2dev",


### PR DESCRIPTION
I ran into the same issue described here: #1047

```
  File "/usr/local/lib/python3.6/dist-packages/googleapiclient/_helpers.py", line 134, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/googleapiclient/discovery.py", line 300, in build
    discovery_http.close()
AttributeError: 'Http' object has no attribute 'close'
```

From that same [issue](https://github.com/googleapis/google-api-python-client/issues/1047#issuecomment-699545589):

```
Having a look at httplib2 changelog, close() method appeared in v0.15.0
```

