### PR TITLE
fix: don't set content-range on empty uploads

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -443,6 +443,33 @@ class TestMediaIoBaseUpload(unittest.TestCase):
         request._sleep.assert_not_called()
 
 
+    def test_media_io_base_empty_file(self):
+        fd = BytesIO()
+        upload = MediaIoBaseUpload(
+            fd=fd, mimetype="image/png", chunksize=500, resumable=True
+        )
+
+        http = HttpMockSequence(
+            [
+                ({"status": "200", "location": "https://www.googleapis.com/someapi/v1/upload?foo=bar"}, "{}"),
+                ({"status": "200", "location": "https://www.googleapis.com/someapi/v1/upload?foo=bar"}, "{}")
+            ]
+        )
+
+        model = JsonModel()
+        uri = u"https://www.googleapis.com/someapi/v1/upload/?foo=bar"
+        method = u"POST"
+        request = HttpRequest(
+            http, model.response, uri, method=method, headers={}, resumable=upload
+        )
+
+        request.execute()
+
+        # Check that "Content-Range" header is not set in the PUT request
+        self.assertTrue("Content-Range" not in http.request_sequence[-1][-1])
+        self.assertEqual("0", http.request_sequence[-1][-1]["Content-Length"])
+
+
 class TestMediaIoBaseDownload(unittest.TestCase):
     def setUp(self):
         http = HttpMock(datafile("zoo.json"), {"status": "200"})


### PR DESCRIPTION
Fixes #638 🦕

Setting the `content-range` header on an empty resumable upload results in 400 Invalid Argument. Only set the `content-range` if there is content. This is what the Java discovery client does ([code](https://github.com/googleapis/google-api-java-client/blob/326370e0ec4351aaea21da271692b2fb9585a28c/google-api-client/src/main/java/com/google/api/client/googleapis/media/MediaHttpDownloader.java#L242-L255)).

TODO:
- [x] add unit test case