### PR TITLE
fix: don't raise when downloading zero byte files

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -745,8 +745,16 @@ class MediaIoBaseDownload(object):
             if self._total_size is None or self._progress == self._total_size:
                 self._done = True
             return MediaDownloadProgress(self._progress, self._total_size), self._done
-        else:
-            raise HttpError(resp, content, uri=self._uri)
+        elif resp.status == 416:
+            # 416 is Range Not Satisfiable
+            # This typically occurs with a zero byte file
+            content_range = resp["content-range"]
+            length = content_range.rsplit("/", 1)[1]
+            self._total_size = int(length)
+            if self._total_size == 0:
+                self._done = True
+                return MediaDownloadProgress(self._progress, self._total_size), self._done
+        raise HttpError(resp, content, uri=self._uri)
 
 
 class _StreamSlice(object):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -672,6 +672,26 @@ class TestMediaIoBaseDownload(unittest.TestCase):
         self.assertEqual(0, download._total_size)
         self.assertEqual(0, status.progress())
 
+    def test_media_io_base_download_empty_file_416_response(self):
+        self.request.http = HttpMockSequence(
+            [({"status": "416", "content-range": "0-0/0"}, b"")]
+        )
+
+        download = MediaIoBaseDownload(fd=self.fd, request=self.request, chunksize=3)
+
+        self.assertEqual(self.fd, download._fd)
+        self.assertEqual(0, download._progress)
+        self.assertEqual(None, download._total_size)
+        self.assertEqual(False, download._done)
+        self.assertEqual(self.request.uri, download._uri)
+
+        status, done = download.next_chunk()
+
+        self.assertEqual(True, done)
+        self.assertEqual(0, download._progress)
+        self.assertEqual(0, download._total_size)
+        self.assertEqual(0, status.progress())
+
     def test_media_io_base_download_unknown_media_size(self):
         self.request.http = HttpMockSequence([({"status": "200"}, b"123")])
 


### PR DESCRIPTION
Don't raise on 416 Range Not Satisfied if there is no content to download. This is similar to fix in resumable media https://github.com/googleapis/google-resumable-media-python/pull/86/.

Fixes #638 

