### PR TITLE
Build update from 'searchconsole' to 'webmasters'

### DIFF
--- a/samples/searchconsole/search_analytics_api_sample.py
+++ b/samples/searchconsole/search_analytics_api_sample.py
@@ -55,7 +55,7 @@ argparser.add_argument('end_date', type=str,
 
 def main(argv):
   service, flags = sample_tools.init(
-      argv, 'searchconsole', 'v1', __doc__, __file__, parents=[argparser],
+      argv, 'webmasters', 'v3', __doc__, __file__, parents=[argparser],
       scope='https://www.googleapis.com/auth/webmasters.readonly')
 
   # First run a query to learn which dates we have data for. You should always


### PR DESCRIPTION
Google announced it wouldn't support the searchconsole API after 31.12.2020. Changing the build allows to still use the example 

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-api-python-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
