### PR TITLE
fix(deps): add upper-bound google-auth dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ packages = ["apiclient", "googleapiclient", "googleapiclient/discovery_cache"]
 
 install_requires = [
     "httplib2>=0.15.0,<1dev",
-    "google-auth>=1.16.0",
+    "google-auth>=1.16.0,<2dev",
     "google-auth-httplib2>=0.0.3",
     "google-api-core>=1.21.0,<2dev",
     "six>=1.13.0,<2dev",


### PR DESCRIPTION
For consistency with google-api-core, which specifies
`google-auth >= 1.21.1, < 2.0dev` as a dependency.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-api-python-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1179 🦕
