### PR TITLE
chore(v1): Pin rsa to 4.5 for Python 2.7 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ install_requires = [
     "google-auth>=1.16.0",
     "google-auth-httplib2>=0.0.3",
     "google-api-core>=1.21.0,<2dev",
+    # rsa version 4.5 is the last version that is compatible with Python 2.7
+    "rsa==4.5;python_version<'3'",
     "six>=1.13.0,<2dev",
     "uritemplate>=3.0.0,<4dev",
 ]

--- a/tests/test__auth.py
+++ b/tests/test__auth.py
@@ -89,7 +89,7 @@ class TestAuthWithGoogleAuth(unittest.TestCase):
 
         self.assertNotEqual(credentials, returned)
         self.assertEqual(returned, credentials.with_scopes.return_value)
-        credentials.with_scopes.assert_called_once_with(mock.sentinel.scopes)
+        credentials.with_scopes.assert_called_once_with(mock.sentinel.scopes, default_scopes=None)
 
     def test_authorized_http(self):
         credentials = mock.Mock(spec=google.auth.credentials.Credentials)


### PR DESCRIPTION
As python 2.7 is no longer supported in master, this fix is only intended for the [v1](https://github.com/googleapis/google-api-python-client/tree/v1) branch where we still have support for python 2.7.

Fixes #1204 🦕
