### PR TITLE
fix: add static discovery docs 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include apiclient *.json *.py
+recursive-include googleapiclient *.json *.py
 include CHANGELOG
 include LICENSE
 include README


### PR DESCRIPTION
Fixes #1214 

The [MANIFEST.in](https://packaging.python.org/guides/using-manifest-in/) controls which files are included in the published package.

You can verify that this fixes the problem (missing discovery docs leading to failing `discovery.build()` calls) by building the package and installing the library from the tarfile.


- `python3 -m venv env`
- `source env/bin/activate`
- `python3 -m setup.py sdist`
- `python3 -m pip install dist/google-api-python-client-2.0.0.tar.gz`


```
(env) busunkim@busunkim:~/github/google-api-python-client$ python3
Python 3.6.9 (default, Feb 24 2020, 21:10:07) 
[GCC 9.2.1 20190909] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import googleapiclient
>>> from googleapiclient import discovery
>>> client = discovery.build("cloudprofiler", "v2")
>>> 
```