### PR TITLE
fix: Include discovery artifacts in published package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     install_requires=install_requires,
     python_requires=">=3.6",
     packages=packages,
-    package_data={},
+    package_data={"googleapiclient": ["discovery_cache/documents/*.json"]},
     license="Apache 2.0",
     keywords="google api client",
     classifiers=[


### PR DESCRIPTION
Fixes #1214  🦕

I was able to re-create the issue by using the following steps.
1) Create a clean `pyenv` environment
2) Download google-api-python-client-2.0.1 from PyPi [here](https://files.pythonhosted.org/packages/dc/67/a228c05a28288fdfde6e8c1a27a62e10ee265664c0f1d59070e6e0dc6242/google-api-python-client-2.0.1.tar.gz) and unzip it
3) Install it using `pip install <Unzipped Directory>`
4) Confirm `discovery.build()` fails on any call

To Verify the fix, repeat the steps above, but apply the update in this PR prior to installing the library.