### PR TITLE
chore: fix if statement in github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,7 @@ jobs:
   build:
     name: Update Discovery Artifacts PR
     runs-on: ubuntu-latest
-    if: |
-      ${{github.repository == 'googleapis/google-api-python-client'}}
+    if: ${{github.repository == 'googleapis/google-api-python-client'}}
     steps:
       - name: Get current date
         id: date


### PR DESCRIPTION
PR #1343 was supposed to fix #1342 but the issue still persists. See [this](https://github.com/parthea/google-api-python-client/actions/runs/824759723) github action from my fork.

The root cause turned out to be the multiline format of the `if` statement of `main.yml`. I expected the pipe `|` character to allow `if` statements to be used in a multiline format however the actual behaviour is different than I expected. This PR converts the check to a single line `if` statement.

Using the fix in this PR the workflow was correctly skipped in parthea/google-api-python-client/pull/1.