### PR TITLE
chore: Add @yoshi-approver to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,10 @@
 # The python-samples-reviewers team is the default owner for samples changes
 /samples/  @googleapis/python-samples-owners
 
+# For more information, see https://github.com/googleapis/repo-automation-bots/blob/master/packages/auto-approve/README.md
 .github/auto-approve.yml @googleapis/github-automation @googleapis/yoshi-python
+
+# The following is needed to auto-approve changes to static discovery artifacts and generated documentation.
+/docs/dyn/*.html                                         @yoshi-approver @googleapis/yoshi-python
+/googleapiclient/discovery_cache/documents/*.json        @yoshi-approver @googleapis/yoshi-python
+/googleapiclient/discovery_cache/documents/index.md      @yoshi-approver @googleapis/yoshi-python


### PR DESCRIPTION
Adds @yoshi-approver to CODEOWNERS so PRs like [this](https://github.com/googleapis/google-api-python-client/pull/1359) can be auto-approved.
