### PR TITLE
chore: fix CODEOWNERS typo for /docs/dyn/index.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,5 +15,5 @@
 
 # The following is needed to auto-approve changes to static discovery artifacts and generated documentation.
 /docs/dyn/*.html                                         @yoshi-approver @googleapis/yoshi-python
+/docs/dyn/index.md                                       @yoshi-approver @googleapis/yoshi-python
 /googleapiclient/discovery_cache/documents/*.json        @yoshi-approver @googleapis/yoshi-python
-/googleapiclient/discovery_cache/documents/index.md      @yoshi-approver @googleapis/yoshi-python


### PR DESCRIPTION
PR https://github.com/googleapis/google-api-python-client/pull/1372 for updating static discovery artifacts wasn't approved automatically. The issue is that `/docs/dyn/index.md` was not in the `CODEOWNERS` file due to a copy paste error in https://github.com/googleapis/google-api-python-client/pull/1360.