### PR TITLE
fix: resolve issue where certain artifacts would not be updated

### DIFF
--- a/describe.py
+++ b/describe.py
@@ -403,9 +403,7 @@ def document_api(name, version, uri, doc_destination_dir):
     if resp.status == 200:
         discovery = json.loads(content)
         service = build_from_document(discovery)
-        version = safe_version(version)
-        doc_name = "{}.{}.json".format(name, version.replace("_", ""))
-
+        doc_name = "{}.{}.json".format(name, version)
         discovery_file_path = DISCOVERY_DOC_DIR / doc_name
         revision = None
 
@@ -435,7 +433,7 @@ def document_api(name, version, uri, doc_destination_dir):
         return
 
     document_collection_recursive(
-        service, "{}_{}.".format(name, version), discovery, discovery, doc_destination_dir
+        service, "{}_{}.".format(name, safe_version(version)), discovery, discovery, doc_destination_dir
     )
 
 


### PR DESCRIPTION
Fixes #1384

This PR is also a partial fix for #1330 where there are duplicate discovery artifacts for the same API and version. The issue is that in `describe.py` there is a call to `safe_version()` which is changing the version to remove decimal places.

For example, the following artifacts exist
https://github.com/googleapis/google-api-python-client/blob/master/googleapiclient/discovery_cache/documents/adexchangebuyer.v1.2.json
https://github.com/googleapis/google-api-python-client/blob/master/googleapiclient/discovery_cache/documents/adexchangebuyer.v12.json

For `adexchangebuyer` version `v.1.2`, instead of  this
```
from googleapiclient.discovery import build
build('adexchangebuyer', 'v1.2')
```
we would have this.
```
from googleapiclient.discovery import build
build('adexchangebuyer', 'v12')
```

This PR fixes the versioning issue. The reason that this is a partial fix for #1330 is that another PR is needed to actually delete the duplicated discovery artifacts.

To validate this change, run [updatediscoveryartifacts.py](https://github.com/googleapis/google-api-python-client/blob/master/scripts/updatediscoveryartifacts.py) locally and you should see `adexchangebuyer.v1.2.json` updated.

Once this is merged, I'll trigger the GitHub action that updates discovery artifacts. This PR should not be a breaking change as it won't result in deleting discovery artifacts.