### PR TITLE
fix: update content-length header for next page requests

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -1283,6 +1283,9 @@ Returns:
             body = model.deserialize(request.body)
             body[pageTokenName] = nextPageToken
             request.body = model.serialize(body)
+            request.body_size = len(request.body)
+            if "content-length" in request.headers:
+              del request.headers["content-length"]
             logger.debug("Next page request body: %s %s" % (methodName, body))
 
         return request

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -2172,6 +2172,9 @@ class Next(unittest.TestCase):
         next_request = logging.entries().list_next(request, {"nextPageToken": "123abc"})
         body = JsonModel().deserialize(next_request.body)
         self.assertEqual(body["pageToken"], "123abc")
+        # The body is changed, make sure that body_length is changed too (see
+        # github #1403)
+        self.assertEqual(next_request.body_size, len(next_request.body))
 
     def test_next_with_method_with_no_properties(self):
         self.http = HttpMock(datafile("latitude.json"), {"status": "200"})


### PR DESCRIPTION
The content-length header only gets updated at request object initialization, so make sure we update it here after we modified the body.

Fixes #1403
