### PR TITLE
chore: Limit Github Action to run once per week

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,8 @@ name: A workflow for updating discovery artifacts
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # Run this Github Action every day at 7 AM UTC
-    - cron:  '0 7 * * *'
+    # Run this Github Action every Tuesday at 7 AM UTC
+    - cron:  '0 7 * * 2'
 
 jobs:
   build:


### PR DESCRIPTION
Right now the Github Action that updates discovery artifacts runs every day at 7 am UTC. Since we typically only release `google-api-python-client` once per week, I'd like to modify the action to only update discovery artifacts once per week.