### PR TITLE
fix: remove repeated calls to self._get_reason

### DIFF
--- a/googleapiclient/errors.py
+++ b/googleapiclient/errors.py
@@ -43,7 +43,7 @@ class HttpError(Error):
         self.content = content
         self.uri = uri
         self.error_details = ""
-        self._get_reason()
+        self.reason = self._get_reason()
 
     @property
     def status_code(self):
@@ -75,25 +75,24 @@ class HttpError(Error):
             pass
         if reason is None:
             reason = ""
-        return reason
+        return reason.strip()
 
     def __repr__(self):
-        reason = self._get_reason()
         if self.error_details:
             return '<HttpError %s when requesting %s returned "%s". Details: "%s">' % (
                 self.resp.status,
                 self.uri,
-                reason.strip(),
+                self.reason,
                 self.error_details,
             )
         elif self.uri:
             return '<HttpError %s when requesting %s returned "%s">' % (
                 self.resp.status,
                 self.uri,
-                self._get_reason().strip(),
+                self.reason,
             )
         else:
-            return '<HttpError %s "%s">' % (self.resp.status, self._get_reason())
+            return '<HttpError %s "%s">' % (self.resp.status, self.reason)
 
     __str__ = __repr__
 


### PR DESCRIPTION
self._get_reason is being called in \_\_init\_\_ (https://github.com/googleapis/google-api-python-client/pull/1185)  , so why not save it then?
also in the \_\_repr\_\_ function we got the reason by calling the _get_reason function right in the beginning, but was then called again.