### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,4 +1,3 @@
-
 {
     "name": "google-api-python-client",
     "name_pretty": "Google API Python Client",
@@ -8,5 +7,7 @@
     "language": "python",
     "library_type": "REST",
     "repo": "googleapis/google-api-python-client",
-    "distribution_name": "google-api-python-client"
-  }
+    "distribution_name": "google-api-python-client",
+    "default_version": "",
+    "codeowner_team": ""
+}


### PR DESCRIPTION
Both `default_version` and `codeowner_team` have empty strings for this repo. By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs. 

https://github.com/googleapis/synthtool/pull/1201
https://github.com/googleapis/synthtool/pull/1114