### PR TITLE
feat: enable self signed jwt for service account credentials

### DIFF
--- a/tests/data/service_account.json
+++ b/tests/data/service_account.json
@@ -1,0 +1,10 @@
+{
+    "type": "service_account",
+    "project_id": "example-project",
+    "private_key_id": "1",
+    "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA4ej0p7bQ7L/r4rVGUz9RN4VQWoej1Bg1mYWIDYslvKrk1gpj\n7wZgkdmM7oVK2OfgrSj/FCTkInKPqaCR0gD7K80q+mLBrN3PUkDrJQZpvRZIff3/\nxmVU1WeruQLFJjnFb2dqu0s/FY/2kWiJtBCakXvXEOb7zfbINuayL+MSsCGSdVYs\nSliS5qQpgyDap+8b5fpXZVJkq92hrcNtbkg7hCYUJczt8n9hcCTJCfUpApvaFQ18\npe+zpyl4+WzkP66I28hniMQyUlA1hBiskT7qiouq0m8IOodhv2fagSZKjOTTU2xk\nSBc//fy3ZpsL7WqgsZS7Q+0VRK8gKfqkxg5OYQIDAQABAoIBAQDGGHzQxGKX+ANk\nnQi53v/c6632dJKYXVJC+PDAz4+bzU800Y+n/bOYsWf/kCp94XcG4Lgsdd0Gx+Zq\nHD9CI1IcqqBRR2AFscsmmX6YzPLTuEKBGMW8twaYy3utlFxElMwoUEsrSWRcCA1y\nnHSDzTt871c7nxCXHxuZ6Nm/XCL7Bg8uidRTSC1sQrQyKgTPhtQdYrPQ4WZ1A4J9\nIisyDYmZodSNZe5P+LTJ6M1SCgH8KH9ZGIxv3diMwzNNpk3kxJc9yCnja4mjiGE2\nYCNusSycU5IhZwVeCTlhQGcNeV/skfg64xkiJE34c2y2ttFbdwBTPixStGaF09nU\nZ422D40BAoGBAPvVyRRsC3BF+qZdaSMFwI1yiXY7vQw5+JZh01tD28NuYdRFzjcJ\nvzT2n8LFpj5ZfZFvSMLMVEFVMgQvWnN0O6xdXvGov6qlRUSGaH9u+TCPNnIldjMP\nB8+xTwFMqI7uQr54wBB+Poq7dVRP+0oHb0NYAwUBXoEuvYo3c/nDoRcZAoGBAOWl\naLHjMv4CJbArzT8sPfic/8waSiLV9Ixs3Re5YREUTtnLq7LoymqB57UXJB3BNz/2\neCueuW71avlWlRtE/wXASj5jx6y5mIrlV4nZbVuyYff0QlcG+fgb6pcJQuO9DxMI\naqFGrWP3zye+LK87a6iR76dS9vRU+bHZpSVvGMKJAoGAFGt3TIKeQtJJyqeUWNSk\nklORNdcOMymYMIlqG+JatXQD1rR6ThgqOt8sgRyJqFCVT++YFMOAqXOBBLnaObZZ\nCFbh1fJ66BlSjoXff0W+SuOx5HuJJAa5+WtFHrPajwxeuRcNa8jwxUsB7n41wADu\nUqWWSRedVBg4Ijbw3nWwYDECgYB0pLew4z4bVuvdt+HgnJA9n0EuYowVdadpTEJg\nsoBjNHV4msLzdNqbjrAqgz6M/n8Ztg8D2PNHMNDNJPVHjJwcR7duSTA6w2p/4k28\nbvvk/45Ta3XmzlxZcZSOct3O31Cw0i2XDVc018IY5be8qendDYM08icNo7vQYkRH\n504kQQKBgQDjx60zpz8ozvm1XAj0wVhi7GwXe+5lTxiLi9Fxq721WDxPMiHDW2XL\nYXfFVy/9/GIMvEiGYdmarK1NW+VhWl1DC5xhDg0kvMfxplt4tynoq1uTsQTY31Mx\nBeF5CT/JuNYk3bEBF0H/Q3VGO1/ggVS+YezdFbLWIRoMnLj6XCFEGg==\n-----END RSA PRIVATE KEY-----\n",
+    "client_email": "service-account@example.com",
+    "client_id": "1234",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://accounts.google.com/o/oauth2/token"
+  }

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -685,6 +685,33 @@ class DiscoveryFromDocument(unittest.TestCase):
             "credentials.json", scopes=None, quota_project_id=None
         )
 
+    def test_self_signed_jwt_enabled(self):
+        service_account_file_path = os.path.join(DATA_DIR, "service_account.json")
+        creds = google.oauth2.service_account.Credentials.from_service_account_file(service_account_file_path)
+
+        discovery = read_datafile("logging.json")
+
+        with mock.patch("google.oauth2.service_account.Credentials._create_self_signed_jwt") as _create_self_signed_jwt:
+            build_from_document(
+                discovery,
+                credentials=creds,
+            )
+            _create_self_signed_jwt.assert_called_with("https://logging.googleapis.com/")
+
+    def test_self_signed_jwt_disabled(self):
+        service_account_file_path = os.path.join(DATA_DIR, "service_account.json")
+        creds = google.oauth2.service_account.Credentials.from_service_account_file(service_account_file_path)
+
+        discovery = read_datafile("logging.json")
+
+        with mock.patch("google.oauth2.service_account.Credentials._create_self_signed_jwt") as _create_self_signed_jwt:
+            build_from_document(
+                discovery,
+                credentials=creds,
+                always_use_jwt_access=False,
+            )
+            _create_self_signed_jwt.assert_not_called()
+
 
 REGULAR_ENDPOINT = "https://www.googleapis.com/plus/v1/"
 MTLS_ENDPOINT = "https://www.mtls.googleapis.com/plus/v1/"


### PR DESCRIPTION
Enable self signed jwt if google-auth service account credentials are used.

Tested with Storage, Compute and PubSub APIs:

```
import googleapiclient.discovery

project = "<project>"
zone = "us-west1-a"

compute = googleapiclient.discovery.build('compute', 'v1')
result = compute.instances().list(project=project, zone=zone).execute()
print(result)

storage = googleapiclient.discovery.build('storage', 'v1')
result = storage.buckets().list(project=project).execute()
print(result)

topic = "<topic>"
pubsub = googleapiclient.discovery.build('pubsub', 'v1')
result = pubsub.projects().topics().get(topic=f"projects/{project}/topics/{topic}").execute()
print(result)
```