### PR TITLE
fix: disable self signed jwt

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -189,7 +189,7 @@ def build(
     adc_key_path=None,
     num_retries=1,
     static_discovery=None,
-    always_use_jwt_access=True,
+    always_use_jwt_access=False,
 ):
     """Construct a Resource for interacting with an API.
 
@@ -447,7 +447,7 @@ def build_from_document(
     client_options=None,
     adc_cert_path=None,
     adc_key_path=None,
-    always_use_jwt_access=True,
+    always_use_jwt_access=False,
 ):
     """Create a Resource for interacting with an API.
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -695,6 +695,7 @@ class DiscoveryFromDocument(unittest.TestCase):
             build_from_document(
                 discovery,
                 credentials=creds,
+                always_use_jwt_access=True,
             )
             _create_self_signed_jwt.assert_called_with("https://logging.googleapis.com/")
 
@@ -708,7 +709,6 @@ class DiscoveryFromDocument(unittest.TestCase):
             build_from_document(
                 discovery,
                 credentials=creds,
-                always_use_jwt_access=False,
             )
             _create_self_signed_jwt.assert_not_called()
 


### PR DESCRIPTION
disable self signed jwt since apiary clients mixed cloud and non-cloud apis.

To enable self signed jwt, users can set `always_use_jwt_access` to True in `build` method.
