### PR TITLE
fix: MediaIoBaseDownload range header off-by-one

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -733,7 +733,7 @@ class MediaIoBaseDownload(object):
         headers = self._headers.copy()
         headers["range"] = "bytes=%d-%d" % (
             self._progress,
-            self._progress + self._chunksize,
+            self._progress + self._chunksize - 1,
         )
         http = self._request.http
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -488,6 +488,23 @@ class TestMediaIoBaseDownload(unittest.TestCase):
         self.assertEqual(5, download._progress)
         self.assertEqual(5, download._total_size)
 
+    def test_media_io_base_download_range_request_header(self):
+        self.request.http = HttpMockSequence(
+            [
+                (
+                    {"status": "200", "content-range": "0-2/5"},
+                    "echo_request_headers_as_json",
+                ),
+            ]
+        )
+
+        download = MediaIoBaseDownload(fd=self.fd, request=self.request, chunksize=3)
+
+        status, done = download.next_chunk()
+        result = json.loads(self.fd.getvalue().decode("utf-8"))
+
+        self.assertEqual(result.get("range"), "bytes=0-2")
+
     def test_media_io_base_download_custom_request_headers(self):
         self.request.http = HttpMockSequence(
             [


### PR DESCRIPTION
Issue: It looks like Range header end value was constructed by adding chunk size to
current position. This leads into the request being one byte longer, and also
the received response body is one byte longer than anticipated.

Fix: adjust the end to be one byte earlier.

For example with `chunksize=1024` and current position being 0, the range header
should be set to `bytes=0-1023`.

See: https://httpwg.org/specs/rfc7233.html#rule.ranges-specifier

Fixes #1593

----

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-api-python-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1593 🦕
