### PR TITLE
fix(deps): allow google-api-core 2.x for python 3 users

### DIFF
--- a/describe.py
+++ b/describe.py
@@ -402,13 +402,25 @@ def document_api(name, version, uri):
             FLAGS.discovery_uri_template, {"api": name, "apiVersion": version}
         )
     )
-    discovery = json.loads(content)
 
-    version = safe_version(version)
+    if response.status == 200:
+        discovery = json.loads(content)
 
-    document_collection_recursive(
-        service, "{}_{}.".format(name, version), discovery, discovery
-    )
+        version = safe_version(version)
+
+        document_collection_recursive(
+            service, "{}_{}.".format(name, version), discovery, discovery
+        )
+    elif resp.status == 404:
+        print(
+            "Warning: {} {} not found. HTTP Code: {}".format(name, version, resp.status)
+        )
+    else:
+        print(
+            "Warning: {} {} could not be built. HTTP Code: {}".format(
+                name, version, resp.status
+            )
+        )
 
 
 def document_api_from_discovery_document(uri):

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,11 @@ packages = ["apiclient", "googleapiclient", "googleapiclient/discovery_cache"]
 
 install_requires = [
     "httplib2>=0.15.0,<1dev",
-    "google-auth>=1.16.0",
+    "google-auth>=1.16.0, <2dev; python_version<'3'",
+    "google-auth>=1.16.0, <3dev; python_version>='3'",
     "google-auth-httplib2>=0.0.3",
-    "google-api-core>=1.21.0,<2dev",
+    "google-api-core>=1.21.0, <2dev; python_version<'3'",
+    "google-api-core>=1.21.0, <3dev; python_version>='3'",
     # rsa version 4.5 is the last version that is compatible with Python 2.7
     "rsa==4.5;python_version<'3'",
     "six>=1.13.0,<2dev",


### PR DESCRIPTION
Fixes #1611

This is being merged to the **v1** branch and will be released manually to PyPI.
