### PR TITLE
chore: release 1.12.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### [1.12.9](https://www.github.com/googleapis/google-api-python-client/compare/v1.12.8...v1.12.9) (2022-01-11)
+
+### Bug Fixes
+
+* allow google-api-core 2.x for python 3 users ([#1649](https://www.github.com/googleapis/google-api-python-client/issues/1649))
+
 ### [1.12.8](https://www.github.com/googleapis/google-api-python-client/compare/v1.12.7...v1.12.8) (2020-11-18)
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ readme_filename = os.path.join(package_root, "README.md")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-version = "1.12.8"
+version = "1.12.9"
 
 setup(
     name="google-api-python-client",


### PR DESCRIPTION

### [1.12.9](https://www.github.com/googleapis/google-api-python-client/compare/v1.12.8...v1.12.9) (2022-01-11)

### Bug Fixes

* allow google-api-core 2.x for python 3 users ([#1649](https://www.github.com/googleapis/google-api-python-client/issues/1649))