### PR TITLE
chore: release 1.12.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### [1.12.10](https://www.github.com/googleapis/google-api-python-client/compare/v1.12.9...v1.12.10) (2022-01-13)
+
+
 ### [1.12.9](https://www.github.com/googleapis/google-api-python-client/compare/v1.12.8...v1.12.9) (2022-01-11)
 
 ### Bug Fixes

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ readme_filename = os.path.join(package_root, "README.md")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-version = "1.12.9"
+version = "1.12.10"
 
 setup(
     name="google-api-python-client",


### PR DESCRIPTION
1.12.9 was not released due to a bug in the release script which was fixed in #1657