### PR TITLE
chore: release 1.12.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+
+### [1.12.11](https://www.github.com/googleapis/google-api-python-client/compare/v1.12.11...v1.12.10) (2022-01-31)
+
+### Bug Fixes
+
+* use version.py instead of pkg_resources ([#1677](https://www.github.com/googleapis/google-api-python-client/issues/1677))
+
+
 ### [1.12.10](https://www.github.com/googleapis/google-api-python-client/compare/v1.12.9...v1.12.10) (2022-01-13)
 
 

--- a/googleapiclient/version.py
+++ b/googleapiclient/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.0" 
+__version__ = "1.12.11"


### PR DESCRIPTION
### Bug Fixes

* use version.py instead of pkg_resources ([#1677](https://www.github.com/googleapis/google-api-python-client/issues/1677))

Also fixes version typo in https://github.com/googleapis/google-api-python-client/pull/1677
