### PR TITLE
chore(revert): revert update actions/github-script action to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
         working-directory: ./scripts
 
       - name: Create PR
-        uses: actions/github-script@v5.1.0
+        uses: actions/github-script@v4.0.2
         with:
           github-token: ${{secrets.YOSHI_CODE_BOT_TOKEN}}
           script: |


### PR DESCRIPTION
Reverts googleapis/google-api-python-client#1676 as the github workflow is failing.