### PR TITLE
chore: reduce commits in discovery document update PR

### DIFF
--- a/scripts/createcommits.sh
+++ b/scripts/createcommits.sh
@@ -33,9 +33,8 @@ do
             git add '../docs/dyn/'$name'_*.html'
             commitmsg=`cat $API_SUMMARY_PATH`
         else
-            # Unstage the files. They will be included in a bulk commit at the end
-            git reset '../googleapiclient/discovery_cache/documents/'$name'.*.json'
-            git reset '../docs/dyn/'$name'_*.html'
+            # Do nothing. The files will be included in a bulk commit at the end
+            continue
         fi
         git commit -m "$commitmsg"
         git rev-parse HEAD>temp/$name'.sha'


### PR DESCRIPTION
PR https://github.com/googleapis/google-api-python-client/pull/1698 contained more than 100 commits. Owl bot has a limit where it cannot support 100 commits in a PR.

The PR reduces the number of commits for the PR where discovery artifacts are updated. We can revert this change once https://github.com/googleapis/repo-automation-bots/issues/3203 is resolved.