### PR TITLE
chore: remove unused imports

### DIFF
--- a/apiclient/__init__.py
+++ b/apiclient/__init__.py
@@ -1,6 +1,5 @@
 """Retain apiclient as an alias for googleapiclient."""
 
-import googleapiclient
 from googleapiclient import channel, discovery, errors, http, mimeparse, model
 
 try:

--- a/describe.py
+++ b/describe.py
@@ -34,7 +34,7 @@ import sys
 
 import uritemplate
 
-from googleapiclient.discovery import DISCOVERY_URI, build, build_from_document
+from googleapiclient.discovery import DISCOVERY_URI, build_from_document
 from googleapiclient.http import build_http
 
 DISCOVERY_DOC_DIR = (

--- a/googleapiclient/discovery_cache/__init__.py
+++ b/googleapiclient/discovery_cache/__init__.py
@@ -37,6 +37,7 @@ def autodetect():
     if "APPENGINE_RUNTIME" in os.environ:
         try:
             from . import appengine_memcache
+
             return appengine_memcache.cache
         except Exception:
             pass

--- a/googleapiclient/discovery_cache/__init__.py
+++ b/googleapiclient/discovery_cache/__init__.py
@@ -16,7 +16,6 @@
 
 from __future__ import absolute_import
 
-import datetime
 import logging
 import os
 
@@ -37,10 +36,7 @@ def autodetect():
     """
     if "APPENGINE_RUNTIME" in os.environ:
         try:
-            from google.appengine.api import memcache
-
             from . import appengine_memcache
-
             return appengine_memcache.cache
         except Exception:
             pass

--- a/googleapiclient/discovery_cache/file_cache.py
+++ b/googleapiclient/discovery_cache/file_cache.py
@@ -27,7 +27,6 @@ import json
 import logging
 import os
 import tempfile
-import threading
 
 try:
     from oauth2client.contrib.locked_file import LockedFile

--- a/samples/adexchangeseller/get_all_alerts.py
+++ b/samples/adexchangeseller/get_all_alerts.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 
 __author__ = 'sgomes@google.com (Sérgio Gomes)'
 
-import argparse
 import sys
 
 from googleapiclient import sample_tools

--- a/samples/adexchangeseller/get_all_dimensions.py
+++ b/samples/adexchangeseller/get_all_dimensions.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 
 __author__ = 'sgomes@google.com (Sérgio Gomes)'
 
-import argparse
 import sys
 
 from googleapiclient import sample_tools

--- a/samples/adexchangeseller/get_all_metrics.py
+++ b/samples/adexchangeseller/get_all_metrics.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 
 __author__ = 'sgomes@google.com (Sérgio Gomes)'
 
-import argparse
 import sys
 
 from googleapiclient import sample_tools

--- a/samples/adexchangeseller/get_all_preferred_deals.py
+++ b/samples/adexchangeseller/get_all_preferred_deals.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 
 __author__ = 'sgomes@google.com (Sérgio Gomes)'
 
-import argparse
 import sys
 
 from googleapiclient import sample_tools

--- a/samples/analytics/hello_analytics_api_v3.py
+++ b/samples/analytics/hello_analytics_api_v3.py
@@ -44,7 +44,6 @@ from __future__ import print_function
 
 __author__ = 'api.nickm@gmail.com (Nick Mihailovski)'
 
-import argparse
 import sys
 
 from googleapiclient.errors import HttpError

--- a/samples/analytics/management_v3_reference.py
+++ b/samples/analytics/management_v3_reference.py
@@ -54,7 +54,6 @@ from __future__ import print_function
 
 __author__ = 'api.nickm@gmail.com (Nick Mihailovski)'
 
-import argparse
 import sys
 
 from googleapiclient.errors import HttpError

--- a/samples/appengine/main.py
+++ b/samples/appengine/main.py
@@ -26,9 +26,7 @@ __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 
 
 import httplib2
-import logging
 import os
-import pickle
 
 from googleapiclient import discovery
 from oauth2client import client

--- a/samples/storage_serviceaccount_appengine/main.py
+++ b/samples/storage_serviceaccount_appengine/main.py
@@ -36,14 +36,10 @@ call Google APIs can be found here:
 __author__ = 'marccohen@google.com (Marc Cohen)'
 
 import httplib2
-import logging
-import os
-import pickle
 import re
 
 from google.appengine.api import memcache
 from google.appengine.ext import webapp
-from google.appengine.ext.webapp import template
 from google.appengine.ext.webapp.util import run_wsgi_app
 from oauth2client.contrib.appengine import AppAssertionCredentials
 

--- a/scripts/buildprbody.py
+++ b/scripts/buildprbody.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import IntEnum
 import pathlib
 
 from changesummary import ChangeType

--- a/scripts/buildprbody_test.py
+++ b/scripts/buildprbody_test.py
@@ -17,11 +17,9 @@
 __author__ = "partheniou@google.com (Anthonios Partheniou)"
 
 import pathlib
-import shutil
 import unittest
 
 from buildprbody import BuildPrBody
-from changesummary import ChangeType
 
 SCRIPTS_DIR = pathlib.Path(__file__).parent.resolve()
 CHANGE_SUMMARY_DIR = SCRIPTS_DIR / "test_resources" / "buildprbody_resources"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -40,7 +40,6 @@ import urllib
 import google.api_core.exceptions
 import google.auth.credentials
 from google.auth.exceptions import MutualTLSChannelError
-from google.auth.transport import mtls
 import google_auth_httplib2
 import httplib2
 import mock
@@ -79,7 +78,6 @@ from googleapiclient.errors import (
     UnknownFileType,
 )
 from googleapiclient.http import (
-    BatchHttpRequest,
     HttpMock,
     HttpMockSequence,
     MediaFileUpload,

--- a/tests/test_discovery_cache.py
+++ b/tests/test_discovery_cache.py
@@ -23,7 +23,6 @@ import unittest
 import mock
 
 from googleapiclient.discovery_cache import DISCOVERY_DOC_MAX_AGE
-from googleapiclient.discovery_cache.base import Cache
 
 try:
     from googleapiclient.discovery_cache.file_cache import Cache as FileCache


### PR DESCRIPTION
Fixes warnings from `flake8 . --select F401`
```
(py39) partheniou@partheniou-vm-2:~/git/google-api-python-client$ flake8 . --select F401
./describe.py:37:1: F401 'googleapiclient.discovery.build' imported but unused
./googleapiclient/discovery_cache/file_cache.py:30:1: F401 'threading' imported but unused
./googleapiclient/discovery_cache/__init__.py:19:1: F401 'datetime' imported but unused
./googleapiclient/discovery_cache/__init__.py:40:13: F401 'google.appengine.api.memcache' imported but unused
./scripts/buildprbody.py:15:1: F401 'enum.IntEnum' imported but unused
./scripts/buildprbody_test.py:20:1: F401 'shutil' imported but unused
./scripts/buildprbody_test.py:24:1: F401 'changesummary.ChangeType' imported but unused
./samples/adexchangeseller/get_all_preferred_deals.py:25:1: F401 'argparse' imported but unused
./samples/adexchangeseller/get_all_metrics.py:25:1: F401 'argparse' imported but unused
./samples/adexchangeseller/get_all_alerts.py:25:1: F401 'argparse' imported but unused
./samples/adexchangeseller/get_all_dimensions.py:25:1: F401 'argparse' imported but unused
./samples/storage_serviceaccount_appengine/main.py:39:1: F401 'logging' imported but unused
./samples/storage_serviceaccount_appengine/main.py:40:1: F401 'os' imported but unused
./samples/storage_serviceaccount_appengine/main.py:41:1: F401 'pickle' imported but unused
./samples/storage_serviceaccount_appengine/main.py:46:1: F401 'google.appengine.ext.webapp.template' imported but unused
./samples/analytics/management_v3_reference.py:57:1: F401 'argparse' imported but unused
./samples/analytics/hello_analytics_api_v3.py:47:1: F401 'argparse' imported but unused
./samples/appengine/main.py:29:1: F401 'logging' imported but unused
./samples/appengine/main.py:31:1: F401 'pickle' imported but unused
./apiclient/__init__.py:3:1: F401 'googleapiclient' imported but unused
./tests/test_discovery.py:43:1: F401 'google.auth.transport.mtls' imported but unused
./tests/test_discovery.py:81:1: F401 'googleapiclient.http.BatchHttpRequest' imported but unused
./tests/test_discovery_cache.py:26:1: F401 'googleapiclient.discovery_cache.base.Cache' imported but unused
```