### PR TITLE
chore: remove unused variables

### DIFF
--- a/describe.py
+++ b/describe.py
@@ -307,7 +307,6 @@ def document_collection(resource, path, root_discovery, discovery, css=CSS):
     """
     collections = []
     methods = []
-    path.split(".")[-2]
     html = [
         "<html><body>",
         css,

--- a/describe.py
+++ b/describe.py
@@ -307,7 +307,7 @@ def document_collection(resource, path, root_discovery, discovery, css=CSS):
     """
     collections = []
     methods = []
-    resource_name = path.split(".")[-2]
+    path.split(".")[-2]
     html = [
         "<html><body>",
         css,
@@ -347,7 +347,6 @@ def document_collection(resource, path, root_discovery, discovery, css=CSS):
     if methods:
         html.append("<h3>Method Details</h3>")
         for name in methods:
-            dname = name.rsplit("_")[0]
             html.append(method(name, getattr(resource, name).__doc__))
 
     html.append("</body></html>")

--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -427,8 +427,8 @@ def _retrieve_discovery_doc(
         pass
 
     try:
-        service = json.loads(content)
-    except ValueError as e:
+        json.loads(content)
+    except ValueError:
         logger.error("Failed to parse as JSON: " + content)
         raise InvalidJsonError()
     if cache_discovery and cache:

--- a/samples/coordinate/coordinate.py
+++ b/samples/coordinate/coordinate.py
@@ -94,7 +94,7 @@ def main(argv):
 
     pprint.pprint(update_result)
 
-  except client.AccessTokenRefreshError as e:
+  except client.AccessTokenRefreshError:
     print ('The credentials have been revoked or expired, please re-run'
       'the application to re-authorize')
 

--- a/tests/test__auth.py
+++ b/tests/test__auth.py
@@ -128,11 +128,11 @@ class TestAuthWithOAuth2Client(unittest.TestCase):
 
     def test_credentials_from_file(self):
         with self.assertRaises(EnvironmentError):
-            credentials = _auth.credentials_from_file("credentials.json")
+            _auth.credentials_from_file("credentials.json")
 
     def test_default_credentials_with_scopes_and_quota_project(self):
         with self.assertRaises(EnvironmentError):
-            credentials = _auth.default_credentials(
+            _auth.default_credentials(
                 scopes=["1", "2"], quota_project_id="my-project"
             )
 

--- a/tests/test__auth.py
+++ b/tests/test__auth.py
@@ -132,9 +132,7 @@ class TestAuthWithOAuth2Client(unittest.TestCase):
 
     def test_default_credentials_with_scopes_and_quota_project(self):
         with self.assertRaises(EnvironmentError):
-            _auth.default_credentials(
-                scopes=["1", "2"], quota_project_id="my-project"
-            )
+            _auth.default_credentials(scopes=["1", "2"], quota_project_id="my-project")
 
     def test_with_scopes_non_scoped(self):
         credentials = mock.Mock(spec=oauth2client.client.Credentials)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -595,7 +595,7 @@ class DiscoveryFromDocument(unittest.TestCase):
 
     def test_building_with_context_manager(self):
         discovery = read_datafile("plus.json")
-        with mock.patch("httplib2.Http") as http:
+        with mock.patch("httplib2.Http"):
             with build_from_document(
                 discovery,
                 base="https://www.googleapis.com/",
@@ -603,7 +603,7 @@ class DiscoveryFromDocument(unittest.TestCase):
             ) as plus:
                 self.assertIsNotNone(plus)
                 self.assertTrue(hasattr(plus, "activities"))
-            http.close.assert_called_once()
+            plus._http.http.close.assert_called_once()
 
     def test_resource_close(self):
         discovery = read_datafile("plus.json")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -243,7 +243,7 @@ class Utilities(unittest.TestCase):
         dummy_schema = {"Request": {"properties": {}}}
         method_desc = {"request": {"$ref": "Request"}}
 
-        parameters = _fix_up_parameters(method_desc, {}, "POST", dummy_schema)
+        _fix_up_parameters(method_desc, {}, "POST", dummy_schema)
 
     def _base_fix_up_method_description_test(
         self,
@@ -440,14 +440,14 @@ class Utilities(unittest.TestCase):
 class Discovery(unittest.TestCase):
     def test_discovery_http_is_closed(self):
         http = HttpMock(datafile("malformed.json"), {"status": "200"})
-        service = build("plus", "v1", credentials=mock.sentinel.credentials)
+        build("plus", "v1", credentials=mock.sentinel.credentials)
         http.close.assert_called_once()
 
 
 class DiscoveryErrors(unittest.TestCase):
     def test_tests_should_be_run_with_strict_positional_enforcement(self):
         try:
-            plus = build("plus", "v1", None, static_discovery=False)
+            build("plus", "v1", None, static_discovery=False)
             self.fail("should have raised a TypeError exception over missing http=.")
         except TypeError:
             pass
@@ -455,7 +455,7 @@ class DiscoveryErrors(unittest.TestCase):
     def test_failed_to_parse_discovery_json(self):
         self.http = HttpMock(datafile("malformed.json"), {"status": "200"})
         try:
-            plus = build(
+            build(
                 "plus",
                 "v1",
                 http=self.http,
@@ -474,7 +474,7 @@ class DiscoveryErrors(unittest.TestCase):
             ]
         )
         with self.assertRaises(UnknownApiNameOrVersion):
-            plus = build("plus", "v1", http=http, cache_discovery=False)
+            build("plus", "v1", http=http, cache_discovery=False)
 
     def test_credentials_and_http_mutually_exclusive(self):
         http = HttpMock(datafile("plus.json"), {"status": "200"})
@@ -603,7 +603,7 @@ class DiscoveryFromDocument(unittest.TestCase):
             ) as plus:
                 self.assertIsNotNone(plus)
                 self.assertTrue(hasattr(plus, "activities"))
-            plus._http.http.close.assert_called_once()
+            http.close.assert_called_once()
 
     def test_resource_close(self):
         discovery = read_datafile("plus.json")
@@ -668,7 +668,7 @@ class DiscoveryFromDocument(unittest.TestCase):
         discovery = read_datafile("plus.json")
 
         with mock.patch("googleapiclient._auth.default_credentials") as default:
-            plus = build_from_document(
+            build_from_document(
                 discovery,
                 client_options={"scopes": ["1", "2"]},
             )
@@ -679,7 +679,7 @@ class DiscoveryFromDocument(unittest.TestCase):
         discovery = read_datafile("plus.json")
 
         with mock.patch("googleapiclient._auth.default_credentials") as default:
-            plus = build_from_document(
+            build_from_document(
                 discovery,
                 client_options=google.api_core.client_options.ClientOptions(
                     quota_project_id="my-project"
@@ -692,7 +692,7 @@ class DiscoveryFromDocument(unittest.TestCase):
         discovery = read_datafile("plus.json")
 
         with mock.patch("googleapiclient._auth.credentials_from_file") as default:
-            plus = build_from_document(
+            build_from_document(
                 discovery,
                 client_options=google.api_core.client_options.ClientOptions(
                     credentials_file="credentials.json"
@@ -977,7 +977,7 @@ class DiscoveryFromHttp(unittest.TestCase):
             http = HttpMockSequence(
                 [({"status": "400"}, read_datafile("zoo.json", "rb"))]
             )
-            zoo = build(
+            build(
                 "zoo",
                 "v1",
                 http=http,
@@ -995,7 +995,7 @@ class DiscoveryFromHttp(unittest.TestCase):
             http = HttpMockSequence(
                 [({"status": "400"}, read_datafile("zoo.json", "rb"))]
             )
-            zoo = build(
+            build(
                 "zoo",
                 "v1",
                 http=http,
@@ -1013,7 +1013,7 @@ class DiscoveryFromHttp(unittest.TestCase):
             http = HttpMockSequence(
                 [({"status": "400"}, read_datafile("zoo.json", "rb"))]
             )
-            zoo = build(
+            build(
                 "zoo",
                 "v1",
                 http=http,
@@ -1232,7 +1232,7 @@ class DiscoveryFromAppEngineCache(unittest.TestCase):
 
             self.mocked_api.memcache.get.return_value = None
 
-            plus = build("plus", "v1", http=self.http, static_discovery=False)
+            build("plus", "v1", http=self.http, static_discovery=False)
 
             # memcache.get is called once
             url = "https://www.googleapis.com/discovery/v1/apis/plus/v1/rest"
@@ -1253,7 +1253,7 @@ class DiscoveryFromAppEngineCache(unittest.TestCase):
             # (Otherwise it should through an error)
             self.http = HttpMock(None, {"status": "200"})
 
-            plus = build("plus", "v1", http=self.http, static_discovery=False)
+            build("plus", "v1", http=self.http, static_discovery=False)
 
             # memcache.get is called twice
             self.mocked_api.memcache.get.assert_has_calls(
@@ -1312,7 +1312,7 @@ class DiscoveryFromFileCache(unittest.TestCase):
         ):
             self.http = HttpMock(datafile("plus.json"), {"status": "200"})
 
-            plus = build("plus", "v1", http=self.http, static_discovery=False)
+            build("plus", "v1", http=self.http, static_discovery=False)
 
             # cache.get is called once
             url = "https://www.googleapis.com/discovery/v1/apis/plus/v1/rest"
@@ -1329,7 +1329,7 @@ class DiscoveryFromFileCache(unittest.TestCase):
             # (Otherwise it should through an error)
             self.http = HttpMock(None, {"status": "200"})
 
-            plus = build("plus", "v1", http=self.http, static_discovery=False)
+            build("plus", "v1", http=self.http, static_discovery=False)
 
             # cache.get is called twice
             cache.get.assert_has_calls([mock.call(url), mock.call(url)])
@@ -1951,7 +1951,7 @@ class Discovery(unittest.TestCase):
         )
 
         try:
-            body = request.execute(http=http)
+            request.execute(http=http)
         except HttpError as e:
             self.assertEqual(b"01234", e.content)
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -323,7 +323,7 @@ class TestMediaIoBaseUpload(unittest.TestCase):
         upload = MediaIoBaseUpload(fd=f, mimetype="image/png")
 
         try:
-            json = upload.to_json()
+            upload.to_json()
             self.fail("MediaIoBaseUpload should not be serializable.")
         except NotImplementedError:
             pass
@@ -960,7 +960,7 @@ class TestHttpRequest(unittest.TestCase):
         request._sleep = lambda _x: 0  # do nothing
         request._rand = lambda: 10
         with self.assertRaises(OSError):
-            response = request.execute(num_retries=3)
+            request.execute(num_retries=3)
 
     def test_retry_connection_errors_non_resumable(self):
         model = JsonModel()
@@ -1238,7 +1238,7 @@ class TestBatch(unittest.TestCase):
             resumable=None,
         )
         # Just testing it shouldn't raise an exception.
-        s = batch._serialize_request(request).splitlines()
+        batch._serialize_request(request).splitlines()
 
     def test_serialize_request_no_body(self):
         batch = BatchHttpRequest()

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -203,9 +203,7 @@ class Mocks(unittest.TestCase):
         )
 
         try:
-            activity = (
-                plus.activities().list(collection="public", userId="me").execute()
-            )
+            plus.activities().list(collection="public", userId="me").execute()
             self.fail("An exception should have been thrown")
         except HttpError as e:
             self.assertEqual(b"{}", e.content)


### PR DESCRIPTION
Fixes warning from `flake8 . --select F841`
```
(py39) partheniou@partheniou-vm-2:~/git/google-api-python-client$ flake8 . --select F841
./describe.py:310:5: F841 local variable 'resource_name' is assigned to but never used
./describe.py:350:13: F841 local variable 'dname' is assigned to but never used
./googleapiclient/discovery.py:430:9: F841 local variable 'service' is assigned to but never used
./googleapiclient/discovery.py:431:5: F841 local variable 'e' is assigned to but never used
./samples/coordinate/coordinate.py:97:3: F841 local variable 'e' is assigned to but never used
./tests/test_mocks.py:206:13: F841 local variable 'activity' is assigned to but never used
./tests/test_http.py:326:13: F841 local variable 'json' is assigned to but never used
./tests/test_http.py:963:13: F841 local variable 'response' is assigned to but never used
./tests/test_http.py:1241:9: F841 local variable 's' is assigned to but never used
./tests/test_discovery.py:246:9: F841 local variable 'parameters' is assigned to but never used
./tests/test_discovery.py:443:9: F841 local variable 'service' is assigned to but never used
./tests/test_discovery.py:450:13: F841 local variable 'plus' is assigned to but never used
./tests/test_discovery.py:458:13: F841 local variable 'plus' is assigned to but never used
./tests/test_discovery.py:477:13: F841 local variable 'plus' is assigned to but never used
./tests/test_discovery.py:598:45: F841 local variable 'http' is assigned to but never used
./tests/test_discovery.py:671:13: F841 local variable 'plus' is assigned to but never used
./tests/test_discovery.py:682:13: F841 local variable 'plus' is assigned to but never used
./tests/test_discovery.py:695:13: F841 local variable 'plus' is assigned to but never used
./tests/test_discovery.py:980:13: F841 local variable 'zoo' is assigned to but never used
./tests/test_discovery.py:998:13: F841 local variable 'zoo' is assigned to but never used
./tests/test_discovery.py:1016:13: F841 local variable 'zoo' is assigned to but never used
./tests/test_discovery.py:1256:13: F841 local variable 'plus' is assigned to but never used
./tests/test_discovery.py:1332:13: F841 local variable 'plus' is assigned to but never used
./tests/test_discovery.py:1954:13: F841 local variable 'body' is assigned to but never used
./tests/test__auth.py:131:13: F841 local variable 'credentials' is assigned to but never used
./tests/test__auth.py:135:13: F841 local variable 'credentials' is assigned to but never used
```