### PR TITLE
chore: use isinstance() instead of type comparison

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -698,10 +698,7 @@ def _cast(value, schema_type):
       A string representation of 'value' based on the schema_type.
     """
     if schema_type == "string":
-        if type(value) == type("") or type(value) == type(""):
-            return value
-        else:
-            return str(value)
+        return str(value)
     elif schema_type == "integer":
         return str(int(value))
     elif schema_type == "number":
@@ -709,10 +706,7 @@ def _cast(value, schema_type):
     elif schema_type == "boolean":
         return str(bool(value)).lower()
     else:
-        if type(value) == type("") or type(value) == type(""):
-            return value
-        else:
-            return str(value)
+        return str(value)
 
 
 def _media_size_to_long(maxSize):
@@ -1075,7 +1069,7 @@ def createMethod(methodName, methodDesc, rootDesc, schema):
         for key, value in kwargs.items():
             to_type = parameters.param_types.get(key, "string")
             # For repeated parameters we cast each member of the list.
-            if key in parameters.repeated_params and type(value) == type([]):
+            if key in parameters.repeated_params and isinstance(value, list):
                 cast_value = [_cast(x, to_type) for x in value]
             else:
                 cast_value = _cast(value, to_type)

--- a/googleapiclient/model.py
+++ b/googleapiclient/model.py
@@ -174,7 +174,7 @@ class BaseModel(Model):
             params.update({"alt": self.alt_param})
         astuples = []
         for key, value in params.items():
-            if type(value) == type([]):
+            if isinstance(value, list):
                 for x in value:
                     x = x.encode("utf-8")
                     astuples.append((key, x))
@@ -393,7 +393,7 @@ def makepatch(original, modified):
             # Use None to signal that the element is deleted
             patch[key] = None
         elif original_value != modified_value:
-            if type(original_value) == type({}):
+            if isinstance(original_value, dict):
                 # Recursively descend objects
                 patch[key] = makepatch(original_value, modified_value)
             else:


### PR DESCRIPTION
Fixes warning from `flake8 . --select E721`

```
(py39) partheniou@partheniou-vm-2:~/git/google-api-python-client$ flake8 . --select E721
./googleapiclient/model.py:177:28: E721 do not compare types, use 'isinstance()'
./googleapiclient/model.py:396:37: E721 do not compare types, use 'isinstance()'
./googleapiclient/discovery.py:701:24: E721 do not compare types, use 'isinstance()'
./googleapiclient/discovery.py:712:24: E721 do not compare types, use 'isinstance()'
./googleapiclient/discovery.py:1078:66: E721 do not compare types, use 'isinstance()'
```