### PR TITLE
test: Switch to unittest.mock

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -42,7 +42,6 @@ test_dependencies = [
     "pytest-cov",
     "webtest",
     "coverage",
-    "mock",
 ]
 
 

--- a/tests/test__auth.py
+++ b/tests/test__auth.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import unittest
+from unittest import mock
 
 import google.auth.credentials
 import google_auth_httplib2
 import httplib2
-import mock
 import oauth2client.client
 
 from googleapiclient import _auth

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -15,9 +15,8 @@
 """Unit tests for googleapiclient._helpers."""
 
 import unittest
+from unittest import mock
 import urllib
-
-import mock
 
 from googleapiclient import _helpers
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -35,6 +35,7 @@ import pickle
 import re
 import sys
 import unittest
+from unittest import mock
 import urllib
 
 import google.api_core.exceptions
@@ -42,7 +43,6 @@ import google.auth.credentials
 from google.auth.exceptions import MutualTLSChannelError
 import google_auth_httplib2
 import httplib2
-import mock
 from oauth2client import GOOGLE_TOKEN_URI
 from oauth2client.client import GoogleCredentials, OAuth2Credentials
 from parameterized import parameterized

--- a/tests/test_discovery_cache.py
+++ b/tests/test_discovery_cache.py
@@ -19,8 +19,7 @@
 
 import datetime
 import unittest
-
-import mock
+from unittest import mock
 
 from googleapiclient.discovery_cache import DISCOVERY_DOC_MAX_AGE
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -34,10 +34,10 @@ import socket
 import ssl
 import time
 import unittest
+from unittest import mock
 import urllib
 
 import httplib2
-import mock
 from oauth2client.client import Credentials
 
 from googleapiclient.discovery import build


### PR DESCRIPTION
As of Python 3.4, the unittest module in the standard library has
included mock, which means we can remove one external dependency.

Fixes #1863
