### PR TITLE
Cleaned up the requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,15 +34,9 @@ packages = ["apiclient", "googleapiclient", "googleapiclient/discovery_cache"]
 
 install_requires = [
     "httplib2>=0.15.0,<1dev",
-    # NOTE: Maintainers, please do not require google-auth>=2.x.x
-    # Until this issue is closed
-    # https://github.com/googleapis/google-cloud-python/issues/10566
-    "google-auth>=1.19.0,<3.0.0dev",
+    "google-auth>=2.0.0,<3.0.0dev",
     "google-auth-httplib2>=0.1.0",
-    # NOTE: Maintainers, please do not require google-api-core>=2.x.x
-    # Until this issue is closed
-    # https://github.com/googleapis/google-cloud-python/issues/10566
-    "google-api-core >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
+    "google-api-core>=2.0.0,<3.0.0dev",
     "uritemplate>=3.0.1,<5",
 ]
 


### PR DESCRIPTION
The [mentioned issue](https://github.com/googleapis/google-cloud-python/issues/10566) has been closed, mentioning that dependencies are compatible with 2.x.x as of April 2022 ([see comment](https://github.com/googleapis/google-cloud-python/issues/10566#issuecomment-1092148447)).

Though, I'm not sure if `>=2.0.0,<3.0.0dev` is the condition that you want.

Cheers
