### PR TITLE
docs: fix a typo in UPGRADING.md related to static_discovery

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -29,8 +29,8 @@ are included in the library. Users of private APIs should set the
 `static_discovery` argument of `discovery.build()` to `False` to continue to
 retrieve the service definition from the internet. As of version 2.1.0,
 for backwards compatibility with version 1.x, if `static_discovery` is not
-specified, the default value for `static_discovery` will be `True` when
-the `discoveryServiceUrl` argument of `discovery.build()` is not provided.
+specified, the default value for `static_discovery` will be `False` when
+the `discoveryServiceUrl` argument of `discovery.build()` is provided.
 
 If you experience issues or have questions, please file an [issue](https://github.com/googleapis/google-api-python-client/issues).
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -30,7 +30,7 @@ are included in the library. Users of private APIs should set the
 retrieve the service definition from the internet. As of version 2.1.0,
 for backwards compatibility with version 1.x, if `static_discovery` is not
 specified, the default value for `static_discovery` will be `True` when
-the `discoveryServiceUrl` argument of `discovery.build()` is provided.
+the `discoveryServiceUrl` argument of `discovery.build()` is not provided.
 
 If you experience issues or have questions, please file an [issue](https://github.com/googleapis/google-api-python-client/issues).
 


### PR DESCRIPTION
See the code below 

https://github.com/googleapis/google-api-python-client/blob/cb89554f28463ce707081aee95244127e963cfdf/googleapiclient/discovery.py#L270-L274

This PR proposes that we change the wording in `UPGRADING.md` from

```
if `static_discovery` is not
specified, the default value for `static_discovery` will be `True` when
the `discoveryServiceUrl` argument of `discovery.build()` is provided.
```
to
```
if `static_discovery` is not
specified, the default value for `static_discovery` will be `False` when
the `discoveryServiceUrl` argument of `discovery.build()` is provided.
```
