### PR TITLE
test: Support running the test suite without oauth2client

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -84,6 +84,7 @@ def format(session):
 @nox.parametrize(
     "oauth2client",
     [
+        None,
         "oauth2client<2dev",
         "oauth2client>=2,<=3dev",
         "oauth2client>=3,<=4dev",
@@ -96,7 +97,8 @@ def unit(session, oauth2client):
     shutil.rmtree("build", ignore_errors=True)
 
     session.install(*test_dependencies)
-    session.install(oauth2client)
+    if oauth2client is not None:
+        session.install(oauth2client)
 
     # Create and install wheels
     session.run("python3", "setup.py", "bdist_wheel")

--- a/tests/test__auth.py
+++ b/tests/test__auth.py
@@ -18,7 +18,13 @@ from unittest import mock
 import google.auth.credentials
 import google_auth_httplib2
 import httplib2
-import oauth2client.client
+
+try:
+    import oauth2client.client
+
+    HAS_OAUTH2CLIENT = True
+except ImportError:
+    HAS_OAUTH2CLIENT = False
 
 from googleapiclient import _auth
 
@@ -105,6 +111,7 @@ class TestAuthWithGoogleAuth(unittest.TestCase):
         self.assertGreater(authorized_http.http.timeout, 0)
 
 
+@unittest.skipIf(not HAS_OAUTH2CLIENT, "oauth2client unavailable.")
 class TestAuthWithOAuth2Client(unittest.TestCase):
     def setUp(self):
         _auth.HAS_GOOGLE_AUTH = False

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -43,10 +43,16 @@ import google.auth.credentials
 from google.auth.exceptions import MutualTLSChannelError
 import google_auth_httplib2
 import httplib2
-from oauth2client import GOOGLE_TOKEN_URI
-from oauth2client.client import GoogleCredentials, OAuth2Credentials
 from parameterized import parameterized
 import uritemplate
+
+try:
+    from oauth2client import GOOGLE_TOKEN_URI
+    from oauth2client.client import GoogleCredentials, OAuth2Credentials
+
+    HAS_OAUTH2CLIENT = True
+except ImportError:
+    HAS_OAUTH2CLIENT = False
 
 from googleapiclient import _helpers as util
 from googleapiclient.discovery import (
@@ -1513,6 +1519,7 @@ class Discovery(unittest.TestCase):
         self.assertTrue(getattr(plus, "activities"))
         self.assertTrue(getattr(plus, "people"))
 
+    @unittest.skipIf(not HAS_OAUTH2CLIENT, "oauth2client unavailable.")
     def test_oauth2client_credentials(self):
         credentials = mock.Mock(spec=GoogleCredentials)
         credentials.create_scoped_required.return_value = False
@@ -2198,6 +2205,7 @@ class Discovery(unittest.TestCase):
             user_agent,
         )
 
+    @unittest.skipIf(not HAS_OAUTH2CLIENT, "oauth2client unavailable.")
     def test_pickle_with_credentials(self):
         credentials = self._dummy_token()
         http = self._dummy_zoo_request()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -38,7 +38,6 @@ from unittest import mock
 import urllib
 
 import httplib2
-from oauth2client.client import Credentials
 
 from googleapiclient.discovery import build
 from googleapiclient.errors import BatchError, HttpError, InvalidChunkSizeError
@@ -60,7 +59,7 @@ from googleapiclient.http import (
 from googleapiclient.model import JsonModel
 
 
-class MockCredentials(Credentials):
+class MockCredentials:
     """Mock class for all Credentials objects."""
 
     def __init__(self, bearer_token, expired=False):


### PR DESCRIPTION
Make it possible to run the test suite without oauth2client, by skipping the few tests that specifically require it.  Given that oauth2client is deprecated, we are aiming towards removing it entirely from Gentoo and the unconditional imports in the test suite are a blocker for that.

I've also added running without oauth2client as an additional nox scenarios but I can remove that if you prefer.