### PR TITLE
fix: remove faulty version matcher in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,16 +33,16 @@ from setuptools import setup
 packages = ["apiclient", "googleapiclient", "googleapiclient/discovery_cache"]
 
 install_requires = [
-    "httplib2>=0.15.0,<1dev",
+    "httplib2>=0.15.0,<1.dev0",
     # NOTE: Maintainers, please do not require google-auth>=2.x.x
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
-    "google-auth>=1.19.0,<3.0.0dev",
+    "google-auth>=1.19.0,<3.0.0.dev0",
     "google-auth-httplib2>=0.1.0",
     # NOTE: Maintainers, please do not require google-api-core>=2.x.x
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
-    "google-api-core >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
+    "google-api-core >= 1.31.5, <3.0.0.dev0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "uritemplate>=3.0.1,<5",
 ]
 


### PR DESCRIPTION
`httplib2<1dev` is ~not~ a valid version matcher (edit: it is valid, just doesn't parse with distlib) in the sense of [PEP 440](https://peps.python.org/pep-0440/).

> The canonical public version identifiers MUST comply with the following scheme:
> `[N!]N(.N)*[{a|b|rc}N][.postN][.devN]`

It is also considered bad practice to have an upper bound on package versions and installers like pip do not consider development versions in any case (unless explicitly told to).

Fixes #2151