### PR TITLE
fix: remove setup.cfg configuration for creating universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
`setup.cfg` contains a setting to create a `Universal Wheel` which is only needed if libraries support both Python 2 and Python 3. This library only supports Python 3 so this setting is no longer needed. See https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#wheels.

See similar PR https://github.com/googleapis/google-cloud-python/pull/13659 which includes this stack trace

```
      running bdist_wheel
      /tmp/pip-build-env-9o_3w17v/overlay/lib/python3.13/site-packages/setuptools/_distutils/cmd.py:135: SetuptoolsDeprecationWarning: bdist_wheel.universal is deprecated
      !!
      
              ********************************************************************************
              With Python 2.7 end-of-life, support for building universal wheels
              (i.e., wheels that support both Python 2 and Python 3)
              is being obviated.
              Please discontinue using this option, or if you still need it,
              file an issue with pypa/setuptools describing your use case.
      
              By 2025-Aug-30, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
              ********************************************************************************
      
      !!
```
