### PR TITLE
test: fix strict positional parameter enforcement under pytest

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,7 +18,4 @@ __author__ = "afshar@google.com (Ali Afshar)"
 
 from googleapiclient import _helpers as util
 
-
-def setup_package():
-    """Run on testing package."""
-    util.positional_parameters_enforcement = "EXCEPTION"
+util.positional_parameters_enforcement = util.POSITIONAL_EXCEPTION


### PR DESCRIPTION
### **Description**
This PR fixes a test suite configuration bug where strict positional parameter checking was silently bypassed when running the tests under `pytest`.

#### **Problem**
Historically, strict positional parameter checking was enabled during test setup by setting `util.positional_parameters_enforcement = "EXCEPTION"` inside a `setup_package()` hook inside `tests/__init__.py`.

However, modern test runs in this repository (including through `nox` sessions) run under **`pytest`**. Unlike the legacy `nose` test runner, **`pytest` does not automatically execute package-level `setup_package()` hooks**. 

Because this hook was ignored:
1. `positional_parameters_enforcement` remained in its default warning-only state.
2. Tests specifically designed to assert strict positional parameter failures (which expect `TypeError`s to be thrown) were being bypassed or would fail if executed directly.

#### **Solution**
1. Moved the setting of `util.positional_parameters_enforcement = "EXCEPTION"` to the **module level** of `tests/__init__.py`. This ensures that the strict check environment is correctly initialized the moment `pytest` imports the `tests` package.
2. Completely removed the dead nose-legacy `setup_package()` hook to keep the codebase clean and free of deprecated test runner baggage.

#### **Verification**
Ran the strict positional test case directly using `pytest` on a clean virtual environment:
```bash
pytest tests/test_discovery.py -k test_tests_should_be_run_with_strict_positional_enforcement
```
* **Before fix**: Test failed with `AssertionError` (only warning log generated, no exception thrown).
* **After fix**: Test successfully passes (raises expected `TypeError` and asserts it correctly).

Fixes #2755