### PR TITLE
test: restore and fix shadowed test_discovery_http_is_closed

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -495,12 +495,6 @@ class Utilities(unittest.TestCase):
         self.assertEqual(parameters.enum_params, {})
 
 
-class Discovery(unittest.TestCase):
-    def test_discovery_http_is_closed(self):
-        http = HttpMock(datafile("malformed.json"), {"status": "200"})
-        service = build("plus", "v1", credentials=mock.sentinel.credentials)
-        http.close.assert_called_once()
-
 
 class DiscoveryErrors(unittest.TestCase):
     def test_tests_should_be_run_with_strict_positional_enforcement(self):
@@ -1535,6 +1529,25 @@ class DiscoveryFromFileCache(unittest.TestCase):
 
 
 class Discovery(unittest.TestCase):
+    @mock.patch("httplib2.Http")
+    def test_discovery_http_is_closed(self, mock_http_class):
+        discovery_mock_http = mock.Mock()
+        discovery_mock_http.redirect_codes = set()
+        service_mock_http = mock.Mock()
+        service_mock_http.redirect_codes = set()
+        
+        discovery_mock_http.request.return_value = (
+            httplib2.Response({"status": "200"}),
+            read_datafile("plus.json"),
+        )
+        
+        mock_http_class.side_effect = [discovery_mock_http, service_mock_http]
+        
+        service = build("plus", "v1", static_discovery=False)
+        
+        discovery_mock_http.close.assert_called_once()
+        service_mock_http.close.assert_not_called()
+
     def test_method_error_checking(self):
         self.http = HttpMock(datafile("plus.json"), {"status": "200"})
         plus = build("plus", "v1", http=self.http, static_discovery=False)


### PR DESCRIPTION
This Pull Request deletes a duplicate test class definition in `test_discovery.py` and restores/fixes a shadowed, previously inactive unit test for HTTP connection lifecycle checks.

#### **The Bug (Problem)**
As reported in #2757, there were two separate definitions for `class Discovery(unittest.TestCase)` in `tests/test_discovery.py` (one at line 498 and one at line 1566). 

In Python, defining a class twice in the same module causes the second definition to silently overwrite the first. Because of this, the first `Discovery` class—which contained the connection lifecycle test **`test_discovery_http_is_closed`**—was completely dead code and was never executed by the test runner.

Furthermore, the original test case was syntactically invalid: it instantiated a regular `HttpMock` object (which does not inherit from mock) but tried to assert `http.close.assert_called_once()`. If it had ever been executed, it would have crashed instantly with an `AttributeError`.

#### **Historical Context**
This shadowing bug was introduced in **September 2020** in commit 98888dadf ("fix: add method to close httplib2 connections (#1038)"). That commit added `test_discovery_http_is_closed` near the top of the file, without realizing that the module already contained an active `class Discovery(unittest.TestCase)` block near the bottom of the file (which immediately shadowed the new test). 

As a result, this important connection-lifecycle test has been silently bypassed and inactive in the test suite for over 5 years.

#### **The Fix (Solution)**
1. Deleted the duplicate `class Discovery` definition near the top of `test_discovery.py`.
2. Restored the `test_discovery_http_is_closed` test inside the active `Discovery` class near the bottom of the file.
3. Corrected the test logic to use standard `unittest.mock.patch` on `httplib2.Http` to verify that the temporary HTTP client created by `build()` to fetch the discovery document is safely closed after initialization completes, preventing socket/connection leaks.

#### **Verification**
Ran the restored test directly under `pytest`:
```bash
pytest tests/test_discovery.py::Discovery::test_discovery_http_is_closed
```
Result: **Passed successfully.**

Fixes #2757
