### PR TITLE
docs: update outdated Google+ references

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,6 +1,6 @@
 # Authentication Overview
 
-This document is an overview of how authentication, authorization, and accounting are accomplished. For all API calls, your application needs to be authenticated. When an API accesses a user's private data, your application must also be authorized by the user to access the data. For example, accessing a public Google+ post would not require user authorization, but accessing a user's private calendar would. Also, for quota and billing purposes, all API calls involve accounting. This document summarizes the protocols used by Google APIs and provides links to more information.
+This document is an overview of how authentication, authorization, and accounting are accomplished. For all API calls, your application needs to be authenticated. When an API accesses a user's private data, your application must also be authorized by the user to access the data. For example, accessing public API data would not require user authorization, but accessing a user's private calendar would. Also, for quota and billing purposes, all API calls involve accounting. This document summarizes the protocols used by Google APIs and provides links to more information.
 
 ## Access types
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -4,7 +4,7 @@ Some API methods may return very large lists of data. To reduce the response siz
 
 To process the first page of results, create a request object and call `execute()` as you normally would. For further pages, you call the corresponding `method_name_next()` method, and pass it the previous request and response. Continue paging until `method_name_next()` returns None.
 
-In the following code snippet, paginated results from an API `list()` method are processed:
+In the following code snippet, paginated results from the legacy Google+ activities API `list()` method are processed:
 
 ```python
 activities = service.activities()

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -4,7 +4,7 @@ Some API methods may return very large lists of data. To reduce the response siz
 
 To process the first page of results, create a request object and call `execute()` as you normally would. For further pages, you call the corresponding `method_name_next()` method, and pass it the previous request and response. Continue paging until `method_name_next()` returns None.
 
-In the following code snippet, the paginated results of a Google Plus activities `list()` method are processed:
+In the following code snippet, paginated results from an API `list()` method are processed:
 
 ```python
 activities = service.activities()

--- a/samples/plus/plus.py
+++ b/samples/plus/plus.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Simple command-line sample for the Google+ API.
+"""Legacy command-line sample for the Google+ API.
 
 Command-line application that retrieves the list of the user's posts."""
 from __future__ import print_function


### PR DESCRIPTION
## Summary

This PR updates outdated Google+ references in documentation and sample text.

## Changes

- Replaced an outdated Google+ example in the authentication documentation
- Generalized the pagination example wording
- Updated the Google+ sample docstring to clarify that it is a legacy sample

## Related issue

Fixes #2754