### PR TITLE
test: fix mTLS auto-enablement unit tests

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -957,23 +957,31 @@ class DiscoveryFromDocumentMutualTLS(unittest.TestCase):
             with mock.patch.dict(
                 "os.environ", {"GOOGLE_API_USE_MTLS_ENDPOINT": use_mtls_env}
             ):
+                # Clear CLOUDSDK_CONTEXT_AWARE_USE_CLIENT_CERTIFICATE so its fallback in
+                # google-auth (often "true" in Cloud SDK environments) does not bypass
+                # certificate_config.json auto-discovery.
                 with mock.patch.dict(
-                    "os.environ", {"GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert}
+                    "os.environ",
+                    {
+                        "GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert,
+                        "CLOUDSDK_CONTEXT_AWARE_USE_CLIENT_CERTIFICATE": "",
+                    },
                 ):
                     with mock.patch("builtins.open", m):
-                        with mock.patch.dict(
-                            "os.environ",
-                            {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename},
-                        ):
-                            plus = build_from_document(
-                                discovery,
-                                credentials=self.MOCK_CREDENTIALS,
-                                client_options={
-                                    "client_encrypted_cert_source": self.client_encrypted_cert_source
-                                },
-                            )
-                            self.assertIsNotNone(plus)
-                            self.assertEqual(plus._baseUrl, base_url)
+                        with mock.patch("os.path.exists", return_value=True):
+                            with mock.patch.dict(
+                                "os.environ",
+                                {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename},
+                            ):
+                                plus = build_from_document(
+                                    discovery,
+                                    credentials=self.MOCK_CREDENTIALS,
+                                    client_options={
+                                        "client_encrypted_cert_source": self.client_encrypted_cert_source
+                                    },
+                                )
+                                self.assertIsNotNone(plus)
+                                self.assertEqual(plus._baseUrl, base_url)
 
     @parameterized.expand(
         [
@@ -1105,22 +1113,30 @@ class DiscoveryFromDocumentMutualTLS(unittest.TestCase):
             with mock.patch.dict(
                 "os.environ", {"GOOGLE_API_USE_MTLS_ENDPOINT": use_mtls_env}
             ):
+                # Clear CLOUDSDK_CONTEXT_AWARE_USE_CLIENT_CERTIFICATE so its fallback in
+                # google-auth (often "true" in Cloud SDK environments) does not bypass
+                # certificate_config.json auto-discovery.
                 with mock.patch.dict(
-                    "os.environ", {"GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert}
+                    "os.environ",
+                    {
+                        "GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert,
+                        "CLOUDSDK_CONTEXT_AWARE_USE_CLIENT_CERTIFICATE": "",
+                    },
                 ):
                     with mock.patch("builtins.open", m):
-                        with mock.patch.dict(
-                            "os.environ",
-                            {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename},
-                        ):
-                            plus = build_from_document(
-                                discovery,
-                                credentials=self.MOCK_CREDENTIALS,
-                                adc_cert_path=self.ADC_CERT_PATH,
-                                adc_key_path=self.ADC_KEY_PATH,
-                            )
-                            self.assertIsNotNone(plus)
-                            self.assertEqual(plus._baseUrl, base_url)
+                        with mock.patch("os.path.exists", return_value=True):
+                            with mock.patch.dict(
+                                "os.environ",
+                                {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename},
+                            ):
+                                plus = build_from_document(
+                                    discovery,
+                                    credentials=self.MOCK_CREDENTIALS,
+                                    adc_cert_path=self.ADC_CERT_PATH,
+                                    adc_key_path=self.ADC_KEY_PATH,
+                                )
+                                self.assertIsNotNone(plus)
+                                self.assertEqual(plus._baseUrl, base_url)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
This PR fixes unit test failures in `tests/test_discovery.py` . See the failure in https://github.com/googleapis/google-api-python-client/pull/2791 as an example

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/test_discovery.py:976: in test_mtls_with_provided_client_cert_unset_environment_variable
    self.assertEqual(plus._baseUrl, base_url)
E   AssertionError: 'https://www.googleapis.com/plus/v1/' != 'https://www.mtls.googleapis.com/plus/v1/'
E   - https://www.googleapis.com/plus/v1/
E   + https://www.mtls.googleapis.com/plus/v1/
E   ? 
```

- **Clear `CLOUDSDK_CONTEXT_AWARE_USE_CLIENT_CERTIFICATE`**: When`GOOGLE_API_USE_CLIENT_CERTIFICATE` is unset, `google-auth` falls back to `CLOUDSDK_CONTEXT_AWARE_USE_CLIENT_CERTIFICATE`. Clearing it ensures pre-existing `"true"` values in Cloud SDK environments do not bypass the auto-discovery of the mock certificate.
- **Mock `os.path.exists`**: Add `mock.patch("os.path.exists", return_value=True)` so `google-auth` detects the mock certificate config file before opening it.