### PR TITLE
ci: Fix update discovery artifacts github action workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,9 +85,12 @@ jobs:
         working-directory: ./scripts
 
       - name: Push changes
-        run: git push -u origin update-discovery-artifacts-${STEPS_DATE_OUTPUTS_CURRENT_DATE}
         env:
-          STEPS_DATE_OUTPUTS_CURRENT_DATE: ${{ steps.date.outputs.current_date }}
+          GH_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+          BRANCH_NAME: update-discovery-artifacts-${{ steps.date.outputs.current_date }}
+        run: |
+          gh auth setup-git
+          git push -u origin "$BRANCH_NAME"
 
       - name: Prepare summary for PR Body
         id: pr_body


### PR DESCRIPTION
The [workflow for updating discovery artifacts is failing](https://github.com/googleapis/google-api-python-client/actions/workflows/main.yml) with `fatal: could not read Username for `

In https://github.com/googleapis/google-api-python-client/pull/2793/changes, `persist-credentials: false` was added which broke the action at the `push changes` step.

This PR fixes the issue by setting up authentication for the `push changes` step