### PR TITLE
fix: replace import urllib with import urllib.parse

### DIFF
--- a/googleapiclient/_helpers.py
+++ b/googleapiclient/_helpers.py
@@ -17,7 +17,7 @@
 import functools
 import inspect
 import logging
-import urllib
+import urllib.parse
 
 logger = logging.getLogger(__name__)
 

--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -37,7 +37,7 @@ import logging
 import mimetypes
 import os
 import re
-import urllib
+import urllib.parse
 
 import google.api_core.client_options
 from google.auth.exceptions import MutualTLSChannelError

--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -32,7 +32,7 @@ import os
 import random
 import socket
 import time
-import urllib
+import urllib.parse
 import uuid
 
 import httplib2

--- a/googleapiclient/model.py
+++ b/googleapiclient/model.py
@@ -26,7 +26,7 @@ __author__ = "jcgregorio@google.com (Joe Gregorio)"
 import json
 import logging
 import platform
-import urllib
+import urllib.parse
 import warnings
 
 from googleapiclient import version as googleapiclient_version


### PR DESCRIPTION
## Description

The modules import `urllib` but call `urllib.parse.*` functions. In Python, importing `urllib` does not import its submodules - `urllib.parse` only becomes accessible after `import urllib.parse` is executed.

This change fixes `AttributeError: module 'urllib' has no attribute 'parse'` when using these modules directly without any prior import of `urllib.parse`.

## Files Changed

- `googleapiclient/_helpers.py`
- `googleapiclient/discovery.py`
- `googleapiclient/http.py`
- `googleapiclient/model.py`

## Fixes

Fixes #2803